### PR TITLE
Display one project

### DIFF
--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -14,6 +14,7 @@ import { classNames } from '../../common/classnames';
 
 import { DashboardView } from '../dashboard/DashboardView';
 import { ListProjectsView } from '../projects/listprojects/ListProjectsView';
+import { ProjectView } from '../projects/project/ProjectView';
 
 import './Main.css';
 
@@ -32,6 +33,7 @@ export const Main = ({ className, ...props }) => {
       <Switch>
         <Route exact path="/" component={DashboardView} />
         <Route exact path="/projects" component={ListProjectsView} />
+        <Route exact path="/projects/:projectName" component={ProjectView} />
       </Switch>
     </main>
   );

--- a/src/components/projects/ProjectHeaderCard.js
+++ b/src/components/projects/ProjectHeaderCard.js
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { classNames } from '../../common/classnames';
+
+import { Card, Header, Title, TITLE_LARGE__KIND } from '../cards/Card';
+
+const PROJECT_HEADER_CARD__CLASS_NAMES = 'projectheadercard';
+
+const propTypes = {
+  name: PropTypes.string.isRequired
+};
+
+/**
+ * The ProjectHeaderCard is used to contain the most important properties of a
+ * project and the main actions used to interact with it.
+ */
+export const ProjectHeaderCard = ({ className, name, ...props }) => {
+  const cardClassNames = classNames(PROJECT_HEADER_CARD__CLASS_NAMES, className);
+  return (
+    <Card className={cardClassNames} {...props}>
+      <Header>
+        <Title kind={TITLE_LARGE__KIND}>{name}</Title>
+      </Header>
+    </Card>
+  );
+};
+ProjectHeaderCard.propTypes = propTypes;

--- a/src/components/projects/ProjectRepresentationsListCard.js
+++ b/src/components/projects/ProjectRepresentationsListCard.js
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { classNames } from '../../common/classnames';
+
+import { Body, Card, Divider, Header, Title } from '../cards/Card';
+import { List, ListItem, LIST_WITH_SEPARATOR__KIND } from '../list/List';
+
+const PROJECT_REPRESENTATIONS_LIST_CARD__CLASS_NAMES = 'projectrepresentationslistcard';
+
+const propTypes = {
+  representations: PropTypes.array.isRequired
+};
+
+const defaultProps = {
+  representations: []
+};
+
+/**
+ * The ProjectRepresentationsListCard is a Card listing all the representations
+ * of a project.
+ */
+export const ProjectRepresentationsListCard = ({ className, representations, ...props }) => {
+  const cardClassNames = classNames(PROJECT_REPRESENTATIONS_LIST_CARD__CLASS_NAMES, className);
+  return (
+    <Card className={cardClassNames} {...props}>
+      <Header>
+        <Title>Representations</Title>
+      </Header>
+      <Divider />
+      <Body>
+        <List kind={LIST_WITH_SEPARATOR__KIND}>
+          {representations.map(representation => (
+            <ListItem key={representation.name}>{representation.name}</ListItem>
+          ))}
+        </List>
+      </Body>
+    </Card>
+  );
+};
+ProjectRepresentationsListCard.propTypes = propTypes;
+ProjectRepresentationsListCard.defaultProps = defaultProps;

--- a/src/components/projects/ProjectSemanticResourcesListCard.js
+++ b/src/components/projects/ProjectSemanticResourcesListCard.js
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { classNames } from '../../common/classnames';
+
+import { Body, Card, Divider, Header, Title } from '../cards/Card';
+import { List, ListItem, LIST_WITH_SEPARATOR__KIND } from '../list/List';
+
+const PROJECT_SEMANTIC_RESOURCES_LIST_CARD__CLASS_NAMES = 'projectsemanticresourceslistcard';
+
+const propTypes = {
+  semanticResources: PropTypes.array.isRequired
+};
+
+const defaultProps = {
+  semanticResources: []
+};
+
+/**
+ * The ProjectSemanticResourcesListCard is a Card displaying all the semantic
+ * resources of a project.
+ */
+export const ProjectSemanticResourcesListCard = ({ className, semanticResources, ...props }) => {
+  const cardClassNames = classNames(PROJECT_SEMANTIC_RESOURCES_LIST_CARD__CLASS_NAMES, className);
+  return (
+    <Card className={cardClassNames} {...props}>
+      <Header>
+        <Title>Semantic Resources</Title>
+      </Header>
+      <Divider />
+      <Body>
+        <List kind={LIST_WITH_SEPARATOR__KIND}>
+          {semanticResources.map(resource => (
+            <ListItem key={resource.path}>{resource.path}</ListItem>
+          ))}
+        </List>
+      </Body>
+    </Card>
+  );
+};
+ProjectSemanticResourcesListCard.propTypes = propTypes;
+ProjectSemanticResourcesListCard.defaultProps = defaultProps;

--- a/src/components/projects/ProjectSummaryCard.css
+++ b/src/components/projects/ProjectSummaryCard.css
@@ -7,6 +7,6 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-.project-card .card-divider {
+.projectsummarycard .card-divider {
   margin-top: var(--layoutDimension-s);
 }

--- a/src/components/projects/ProjectSummaryCard.js
+++ b/src/components/projects/ProjectSummaryCard.js
@@ -10,12 +10,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Body, Card, Header, Title } from '../cards/Card';
+import { Body, Card, Divider, Footer, FooterLink, Header, Title } from '../cards/Card';
 import { List, ListItem, ListItemDescription, ListItemTitle } from '../list/List';
 
 import './ProjectSummaryCard.css';
 
-const PROJECT_CARD__CLASS_NAMES = 'project-card';
+const PROJECT_SUMMARY_CARD__CLASS_NAMES = 'projectsummarycard';
 
 const propTypes = {
   project: PropTypes.object.isRequired
@@ -27,7 +27,7 @@ const propTypes = {
  */
 export const ProjectSummaryCard = ({ project, ...props }) => {
   return (
-    <Card className={PROJECT_CARD__CLASS_NAMES} {...props}>
+    <Card className={PROJECT_SUMMARY_CARD__CLASS_NAMES} {...props}>
       <Header>
         <Title>{project.name}</Title>
       </Header>
@@ -41,6 +41,10 @@ export const ProjectSummaryCard = ({ project, ...props }) => {
           </ListItem>
         </List>
       </Body>
+      <Divider />
+      <Footer>
+        <FooterLink to={`/projects/${project.name}`}>View Project</FooterLink>
+      </Footer>
     </Card>
   );
 };

--- a/src/components/projects/ProjectsListCard.js
+++ b/src/components/projects/ProjectsListCard.js
@@ -11,7 +11,7 @@ import React from 'react';
 import { classNames } from '../../common/classnames';
 
 import { Body, Card, Divider, Header, Title } from '../cards/Card';
-import { LIST_WITH_SEPARATOR__KIND, List, ListItem } from '../list/List';
+import { LIST_WITH_HIGHLIGHT__KIND, LIST_WITH_SEPARATOR__KIND, List, ListItem } from '../list/List';
 
 const PROJECTS_LIST_CARD__CLASS_NAMES = 'projectslistcard';
 
@@ -27,11 +27,19 @@ export const ProjectsListCard = ({ className, ...props }) => {
       </Header>
       <Divider />
       <Body>
-        <List kind={[LIST_WITH_SEPARATOR__KIND]}>
-          <ListItem key={'sirius'}>Sirius</ListItem>
-          <ListItem key={'acceleo'}>Acceleo</ListItem>
-          <ListItem key={'m2doc'}>M2Doc</ListItem>
-          <ListItem key={'emfcompare'}>EMF Compare</ListItem>
+        <List kind={[LIST_WITH_HIGHLIGHT__KIND, LIST_WITH_SEPARATOR__KIND]}>
+          <ListItem key={'sirius'} to={`projects/sirius`}>
+            Sirius
+          </ListItem>
+          <ListItem key={'acceleo'} to={`projects/acceleo`}>
+            Acceleo
+          </ListItem>
+          <ListItem key={'m2doc'} to={`projects/m2doc`}>
+            M2Doc
+          </ListItem>
+          <ListItem key={'emfcompare'} to={`projects/emfcompare`}>
+            EMF Compare
+          </ListItem>
         </List>
       </Body>
     </Card>

--- a/src/components/projects/project/ProjectView.css
+++ b/src/components/projects/project/ProjectView.css
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+.projectview {
+  display: grid;
+  grid-template-rows:
+    [header] min-content
+    [main] auto;
+  grid-template-columns: 1fr;
+  grid-row-gap: var(--layoutDimension-l);
+}
+
+.projectview-main {
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-columns: [details] auto;
+  grid-column-gap: var(--layoutDimension-l);
+}
+
+.projectview-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.projectview-details .card {
+  margin-top: var(--layoutDimension-l);
+}
+.projectview-details .card:nth-child(1) {
+  margin-top: 0;
+}

--- a/src/components/projects/project/ProjectView.js
+++ b/src/components/projects/project/ProjectView.js
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import React from 'react';
+
+import { ProjectHeaderCard } from '../ProjectHeaderCard';
+import { ProjectRepresentationsListCard } from '../ProjectRepresentationsListCard';
+import { ProjectSemanticResourcesListCard } from '../ProjectSemanticResourcesListCard';
+
+import './ProjectView.css';
+
+const PROJECT_VIEW__CLASS_NAMES = 'projectview';
+const PROJECT_VIEW_MAIN__CLASS_NAMES = 'projectview-main';
+const PROJECT_VIEW_DETAILS__CLASS_NAMES = 'projectview-details';
+
+const semanticResources = [
+  { path: 'model/Architecture.ecore' },
+  { path: 'model/Architecture.genmodel' },
+  { path: 'model/Interaction.ecore' },
+  { path: 'model/Interaction.genmodel' }
+];
+
+const representations = [
+  { name: 'Class Diagram' },
+  { name: 'Architecture Diagram' },
+  { name: 'Interaction Diagram' },
+  { name: 'Activity Diagram' },
+  { name: 'Performance Table' }
+];
+
+/**
+ * The ProjectView is used to display and manipulate a project.
+ */
+export const ProjectView = ({ className }) => {
+  return (
+    <div className={PROJECT_VIEW__CLASS_NAMES}>
+      <ProjectHeaderCard name={'Acceleo'} />
+      <div className={PROJECT_VIEW_MAIN__CLASS_NAMES}>
+        <div className={PROJECT_VIEW_DETAILS__CLASS_NAMES}>
+          <ProjectSemanticResourcesListCard semanticResources={semanticResources} />
+          <ProjectRepresentationsListCard representations={representations} />
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
This commit will add a new page displaying the details of one project.
A link has been added from both the dashboard and the list of projects
to a page showing a project.

A project is displayed using the ProjectView component which uses both a
ProjectRepresentationsListCard and a ProjectSemanticResourcesListCard.
On top of the page, the details of the project itself will be visible in
the ProjectHeaderCard component.

Bug: https://github.com/eclipse/sirius-components/issues/6
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non*breaking change which fixes an issue)
* [x] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] Continuous integration improvement