### PR TITLE
Define properly the states of stateful components

### DIFF
--- a/src/common/dispatcherCreator.js
+++ b/src/common/dispatcherCreator.js
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+/**
+ * The dispatcher creator is a function which will create a new dispatcher
+ * initialized thanks to the following parameters:
+ *
+ * First, the finite state machine defining all the states and transitions in
+ * the stateful component. Second, the reducer used to define the behavior of
+ * each transition, allowing the stateful component to move from one state to
+ * another and finally, the initial state of the finite state machine.
+ *
+ * It will then return a dispatcher which will ensure that the reducer cannot
+ * be called to execute an action which is not defined on the current state
+ * starting with the initial state. It will also make sure that the new state
+ * computed by the reducer is accessible from the current state with the action
+ * that the reducer had to execute.
+ *
+ * Failure to comply with those requirements will result in an error logged in
+ * the console and no change will be applied to the returned state.
+ */
+export const dispatcherCreator = (FSM, reducer, INITIAL__STATE) => (
+  prevState = { stateId: INITIAL__STATE },
+  props,
+  action
+) => {
+  let transitions = FSM[prevState.stateId];
+  const newPotentialState = transitions[action.kind];
+  if (newPotentialState) {
+    const newState = reducer(prevState, props, action);
+    if (newPotentialState.includes(newState.stateId)) {
+      return newState;
+    } else {
+      console.error(
+        `The state '${newState.stateId}' should not be accessible from ${
+          prevState.stateId
+        } with the transition ${action.kind}.`
+      );
+    }
+  } else {
+    console.error(
+      `The state '${prevState.stateId}' does not support the transition '${action.kind}'.`
+    );
+  }
+  return prevState;
+};

--- a/src/components/dashboard/DashboardView.js
+++ b/src/components/dashboard/DashboardView.js
@@ -24,13 +24,15 @@ const PROJECTS_BODY__CLASS_NAMES = 'projects-body';
  * It will render a bird eye view of the state of the data of the user starting
  * with the list of the projects available.
  */
-export const DashboardView = ({ className, projects, ...props }) => {
+export const DashboardView = ({ className, dashboard, ...props }) => {
   const dashboardViewClassNames = classNames(DASHBOARD_VIEW__CLASS_NAMES, className);
   return (
     <div className={dashboardViewClassNames} {...props}>
       <div className={PROJECTS__CLASS_NAMES}>
         <div className={PROJECTS_BODY__CLASS_NAMES}>
-          {projects.map(project => <ProjectSummaryCard key={project.name} project={project} />)}
+          {dashboard.projects.map(project => (
+            <ProjectSummaryCard key={project.name} project={project} />
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/dashboard/DashboardViewDispatcher.js
+++ b/src/components/dashboard/DashboardViewDispatcher.js
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import { dispatcherCreator } from '../../common/dispatcherCreator';
+
+import {
+  FSM,
+  INITIAL__STATE,
+  LOADING__STATE,
+  DASHBOARD_LOADED__STATE,
+  HANDLE_FETCHED_DASHBOARD__ACTION,
+  INITIALIZE__ACTION
+} from './DashboardViewFiniteStateMachine';
+
+/**
+ * The reducer of the dashboard view.
+ *
+ * It will be used to execute the transitions in the finite state machine of
+ * the dashboard.
+ *
+ * @param {*} state The current state
+ * @param {*} props The properties of the component
+ * @param {*} action The action to perform
+ */
+const reducer = (state, props, action) => {
+  switch (action.kind) {
+    case INITIALIZE__ACTION:
+      return { stateId: LOADING__STATE, dashboard: { projects: [] }, error: null };
+    case HANDLE_FETCHED_DASHBOARD__ACTION:
+      return { stateId: DASHBOARD_LOADED__STATE, dashboard: action.dashboard, error: null };
+    default:
+      return state;
+  }
+};
+
+/**
+ * Returns an initialize action used to go from the initial state to the
+ * loading state.
+ */
+const newInitializeAction = () => ({
+  kind: INITIALIZE__ACTION
+});
+
+/**
+ * Returns an handle dashboard fetched action used to go from the loading state
+ * to the dashboard loaded state.
+ *
+ * @param {*} response The HTTP response of the server
+ */
+const newHandleDashboardFetchedAction = response => ({
+  kind: HANDLE_FETCHED_DASHBOARD__ACTION,
+  dashboard: response
+});
+
+export const actionCreator = { newInitializeAction, newHandleDashboardFetchedAction };
+
+export const dispatcher = dispatcherCreator(FSM, reducer, INITIAL__STATE);

--- a/src/components/dashboard/DashboardViewFiniteStateMachine.js
+++ b/src/components/dashboard/DashboardViewFiniteStateMachine.js
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+export const INITIAL__STATE = 'INITIAL__STATE';
+export const LOADING__STATE = 'LOADING__STATE';
+export const DASHBOARD_LOADED__STATE = 'DASHBOARD_LOADED__STATE';
+
+export const INITIALIZE__ACTION = 'INITIALIZE__ACTION';
+export const HANDLE_FETCHED_DASHBOARD__ACTION = 'HANDLE_FETCHED_DASHBOARD__ACTION';
+
+export const FSM = {
+  INITIAL__STATE: { INITIALIZE__ACTION: [LOADING__STATE] },
+  LOADING__STATE: {
+    HANDLE_FETCHED_DASHBOARD__ACTION: [DASHBOARD_LOADED__STATE]
+  },
+  DASHBOARD_LOADED__STATE: {}
+};

--- a/src/components/projects/listprojects/ListProjectsViewDispatcher.js
+++ b/src/components/projects/listprojects/ListProjectsViewDispatcher.js
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import { dispatcherCreator } from '../../../common/dispatcherCreator';
+
+import {
+  FSM,
+  INITIAL__STATE,
+  LOADING__STATE,
+  PROJECTS_LOADED__STATE,
+  HANDLE_FETCHED_PROJECTS__ACTION,
+  INITIALIZE__ACTION
+} from './ListProjectsViewFiniteStateMachine';
+
+/**
+ * The reducer of the list projects view.
+ *
+ * It will be used to execute the transitions in the finite state machine of
+ * the list projects view.
+ *
+ * @param {*} state The current state
+ * @param {*} props The properties of the component
+ * @param {*} action The action to perform
+ */
+const reducer = (state, props, action) => {
+  switch (action.kind) {
+    case INITIALIZE__ACTION:
+      return { stateId: LOADING__STATE, projects: [], error: null };
+    case HANDLE_FETCHED_PROJECTS__ACTION:
+      return { stateId: PROJECTS_LOADED__STATE, projects: action.projects, error: null };
+    default:
+      return state;
+  }
+};
+
+/**
+ * Returns an initialize action used to go from the initial state to the
+ * loading state.
+ */
+const newInitializeAction = () => ({
+  kind: INITIALIZE__ACTION
+});
+
+/**
+ * Returns an handle projects fetched action used to go from the loading state
+ * to the projects loaded state.
+ *
+ * @param {*} response The HTTP response of the server
+ */
+const newHandleProjectsFetchedAction = response => ({
+  kind: HANDLE_FETCHED_PROJECTS__ACTION,
+  projects: response.projects
+});
+
+export const actionCreator = {
+  newInitializeAction,
+  newHandleProjectsFetchedAction
+};
+
+export const dispatcher = dispatcherCreator(FSM, reducer, INITIAL__STATE);

--- a/src/components/projects/listprojects/ListProjectsViewFiniteStateMachine.js
+++ b/src/components/projects/listprojects/ListProjectsViewFiniteStateMachine.js
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+export const INITIAL__STATE = 'INITIAL__STATE';
+export const LOADING__STATE = 'LOADING__STATE';
+export const PROJECTS_LOADED__STATE = 'PROJECTS_LOADED__STATE';
+
+export const INITIALIZE__ACTION = 'INITIALIZE__ACTION';
+export const HANDLE_FETCHED_PROJECTS__ACTION = 'HANDLE_FETCHED_PROJECTS__ACTION';
+
+export const FSM = {
+  INITIAL__STATE: { INITIALIZE__ACTION: [LOADING__STATE] },
+  LOADING__STATE: {
+    HANDLE_FETCHED_PROJECTS__ACTION: [PROJECTS_LOADED__STATE]
+  },
+  PROJECTS_LOADED__STATE: {}
+};

--- a/src/components/projects/project/ProjectViewDispatcher.js
+++ b/src/components/projects/project/ProjectViewDispatcher.js
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import { dispatcherCreator } from '../../../common/dispatcherCreator';
+
+import {
+  FSM,
+  INITIAL__STATE,
+  LOADING__STATE,
+  PROJECT_LOADED__STATE,
+  HANDLE_FETCHED_PROJECT__ACTION,
+  INITIALIZE__ACTION
+} from './ProjectViewFiniteStateMachine';
+
+/**
+ * The reducer of the project view.
+ *
+ * It will be used to execute the transitions in the finite state machine of
+ * the project view.
+ *
+ * @param {*} state The current state
+ * @param {*} props The properties of the component
+ * @param {*} action The action to perform
+ */
+const reducer = (state, props, action) => {
+  switch (action.kind) {
+    case INITIALIZE__ACTION:
+      return { stateId: LOADING__STATE, project: null, error: null };
+    case HANDLE_FETCHED_PROJECT__ACTION:
+      return { stateId: PROJECT_LOADED__STATE, project: action.project, error: null };
+    default:
+      return state;
+  }
+};
+
+/**
+ * Returns an initialize action used to go from the initial state to the
+ * loading state.
+ */
+const newInitializeAction = () => ({
+  kind: INITIALIZE__ACTION
+});
+
+/**
+ * Returns an handle project fetched action used to go from the loading state
+ * to the project loaded state.
+ *
+ * @param {*} response The HTTP response of the server
+ */
+const newHandleProjectFetchedAction = response => ({
+  kind: HANDLE_FETCHED_PROJECT__ACTION,
+  project: response
+});
+
+export const actionCreator = {
+  newInitializeAction,
+  newHandleProjectFetchedAction
+};
+
+export const dispatcher = dispatcherCreator(FSM, reducer, INITIAL__STATE);

--- a/src/components/projects/project/ProjectViewFiniteStateMachine.js
+++ b/src/components/projects/project/ProjectViewFiniteStateMachine.js
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+export const INITIAL__STATE = 'INITIAL__STATE';
+export const LOADING__STATE = 'LOADING__STATE';
+export const PROJECT_LOADED__STATE = 'PROJECT_LOADED__STATE';
+
+export const INITIALIZE__ACTION = 'INITIALIZE__ACTION';
+export const HANDLE_FETCHED_PROJECT__ACTION = 'HANDLE_FETCHED_PROJECT__ACTION';
+
+export const FSM = {
+  INITIAL__STATE: {
+    INITIALIZE__ACTION: [LOADING__STATE]
+  },
+  LOADING__STATE: {
+    HANDLE_FETCHED_PROJECT__ACTION: [PROJECT_LOADED__STATE]
+  },
+  PROJECT_LOADED__STATE: {}
+};

--- a/src/containers/dashboard/DashboardViewStateContainer.js
+++ b/src/containers/dashboard/DashboardViewStateContainer.js
@@ -11,6 +11,8 @@ import React, { Component } from 'react';
 
 import { DashboardView } from '../../components/dashboard/DashboardView';
 
+import { actionCreator, dispatcher } from '../../components/dashboard/DashboardViewDispatcher';
+
 /**
  * The DashboardViewStateContainer is the stateful component used to manipulate
  * the state of the dashboard.
@@ -18,26 +20,27 @@ import { DashboardView } from '../../components/dashboard/DashboardView';
 export class DashboardViewStateContainer extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      projects: []
-    };
+    this.state = dispatcher(undefined, props, actionCreator.newInitializeAction());
   }
 
   async componentDidMount() {
     try {
       const jsonDashboardResponse = await fetch(`/api/dashboard`);
-      const jsonDashboard = await jsonDashboardResponse.json();
-      this.setState({
-        projects: jsonDashboard.projects
-      });
+      const dashboardResponse = await jsonDashboardResponse.json();
+      const action = actionCreator.newHandleDashboardFetchedAction(dashboardResponse);
+      this.dispatch(action);
     } catch (error) {
       // To be handled later
     }
   }
 
-  render() {
-    const { projects } = this.state;
+  dispatch(action) {
+    this.setState((prevState, props) => dispatcher(prevState, props, action));
+  }
 
-    return <DashboardView projects={projects} />;
+  render() {
+    const { dashboard } = this.state;
+
+    return <DashboardView dashboard={dashboard} />;
   }
 }

--- a/src/containers/projects/ListProjectsViewStateContainer.js
+++ b/src/containers/projects/ListProjectsViewStateContainer.js
@@ -11,6 +11,11 @@ import React, { Component } from 'react';
 
 import { ListProjectsView } from '../../components/projects/listprojects/ListProjectsView';
 
+import {
+  actionCreator,
+  dispatcher
+} from '../../components/projects/listprojects/ListProjectsViewDispatcher';
+
 /**
  * The ListProjectsViewStateContainer is the stateful component used to manipulate
  * the list of the projects.
@@ -18,17 +23,22 @@ import { ListProjectsView } from '../../components/projects/listprojects/ListPro
 export class ListProjectsViewStateContainer extends Component {
   constructor(props) {
     super(props);
-    this.state = { projects: [] };
+    this.state = dispatcher(undefined, props, actionCreator.newInitializeAction());
   }
 
   async componentDidMount() {
     try {
       const jsonProjectsResponse = await fetch(`/api/projects`);
-      const jsonProjects = await jsonProjectsResponse.json();
-      this.setState({ projects: jsonProjects.projects });
+      const projectsResponse = await jsonProjectsResponse.json();
+      const action = actionCreator.newHandleProjectsFetchedAction(projectsResponse);
+      this.dispatch(action);
     } catch (error) {
       // To be handled later
     }
+  }
+
+  dispatch(action) {
+    this.setState((prevState, props) => dispatcher(prevState, props, action));
   }
 
   render() {

--- a/src/containers/projects/ProjectViewStateContainer.js
+++ b/src/containers/projects/ProjectViewStateContainer.js
@@ -12,6 +12,8 @@ import { withRouter } from 'react-router-dom';
 
 import { ProjectView } from '../../components/projects/project/ProjectView';
 
+import { actionCreator, dispatcher } from '../../components/projects/project/ProjectViewDispatcher';
+
 /**
  * The ProjectViewStateContainerWithoutRouter is the stateful component used to
  * manipulate the state of the ProjectView.
@@ -22,7 +24,7 @@ import { ProjectView } from '../../components/projects/project/ProjectView';
 class ProjectViewStateContainerWithoutRouter extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = dispatcher(undefined, props, actionCreator.newInitializeAction());
   }
 
   async componentDidMount() {
@@ -31,18 +33,21 @@ class ProjectViewStateContainerWithoutRouter extends Component {
       const jsonProjectResponse = await fetch(`/api/projects/${projectName}`);
       const projectResponse = await jsonProjectResponse.json();
 
-      this.setState({
-        project: projectResponse
-      });
+      const action = actionCreator.newHandleProjectFetchedAction(projectResponse);
+      this.dispatch(action);
     } catch (error) {
       // To be handled later
     }
   }
 
+  dispatch(action) {
+    this.setState((prevState, props) => dispatcher(prevState, props, action));
+  }
+
   render() {
     const { project } = this.state;
 
-    if (project === undefined) {
+    if (!project) {
       return <p>Loading</p>;
     }
     return <ProjectView project={project} {...this.props} />;


### PR DESCRIPTION
This commit will add finite state machines in order to define all the
states and transitions that the stateful components can use. All the
transitions between the states have been extracted in reducers.

Dispatchers have been introduced in order to ensure that the transitions
and their results are matching the data of the finite state machine of
the component.

Bug: https://github.com/eclipse/sirius-components/issues/8
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non*breaking change which fixes an issue)
* [ ] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] Continuous integration improvement