### PR TITLE
Define properly the states of stateful components

### DIFF
--- a/src/components/dashboard/DashboardView.js
+++ b/src/components/dashboard/DashboardView.js
@@ -8,23 +8,56 @@
  *******************************************************************************/
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
+import { Loading } from '../loading/Loading';
 import { ProjectSummaryCard } from '../projects/ProjectSummaryCard';
+
+import { LOADING__STATE, DASHBOARD_LOADED__STATE } from './DashboardViewFiniteStateMachine';
 
 import './DashboardView.css';
 
-const DASHBOARD_VIEW__CLASS_NAMES = 'dashboard-view';
-const PROJECTS__CLASS_NAMES = 'projects';
-const PROJECTS_BODY__CLASS_NAMES = 'projects-body';
+const propTypes = {
+  stateId: PropTypes.string.isRequired
+};
 
 /**
  * The DashboardView component is used as the main component in the dashboard page.
  * It will render a bird eye view of the state of the data of the user starting
  * with the list of the projects available.
  */
-export const DashboardView = ({ className, dashboard, ...props }) => {
+export const DashboardView = ({ className, stateId, dashboard, ...props }) => {
+  switch (stateId) {
+    case LOADING__STATE:
+      return renderLoadingState(className, props);
+    case DASHBOARD_LOADED__STATE:
+      return renderDashboardLoadedState(className, dashboard, props);
+    default:
+      return renderLoadingState(className, props);
+  }
+};
+DashboardView.propTypes = propTypes;
+
+/**
+ * Renders the loading state of the dashboard.
+ * @param {*} className The class name of the dashboard.
+ * @param {*} props The properties of the component
+ */
+const renderLoadingState = (className, props) => <Loading className={className} {...props} />;
+
+const DASHBOARD_VIEW__CLASS_NAMES = 'dashboardview';
+const PROJECTS__CLASS_NAMES = 'projects';
+const PROJECTS_BODY__CLASS_NAMES = 'projects-body';
+
+/**
+ * Renders the dashboard.
+ * @param {*} className The class name of the dashboard
+ * @param {*} dashboard The dashboard to display
+ * @param {*} props The properties of the component
+ */
+const renderDashboardLoadedState = (className, dashboard, props) => {
   const dashboardViewClassNames = classNames(DASHBOARD_VIEW__CLASS_NAMES, className);
   return (
     <div className={dashboardViewClassNames} {...props}>

--- a/src/components/loading/Loading.js
+++ b/src/components/loading/Loading.js
@@ -7,10 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-.dashboardview .projects-body {
-  display: grid;
-  grid-template-rows: repeat(auto-fill, minmax(100px, 1fr));
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  grid-row-gap: var(--layoutDimension-l);
-  grid-column-gap: var(--layoutDimension-l);
-}
+import React from 'react';
+
+/**
+ * The Login component is used to display that we are waiting for some
+ * asynchronous process to finish like a request to a server.
+ */
+export const Loading = props => {
+  return <div {...props}>Loading</div>;
+};

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -12,6 +12,10 @@ import { Route, Switch } from 'react-router-dom';
 
 import { classNames } from '../../common/classnames';
 
+import { DashboardView } from '../dashboard/DashboardView';
+import { ListProjectsView } from '../projects/listprojects/ListProjectsView';
+import { ProjectView } from '../projects/project/ProjectView';
+
 import { DashboardViewStateContainer } from '../../containers/dashboard/DashboardViewStateContainer';
 import { ListProjectsViewStateContainer } from '../../containers/projects/ListProjectsViewStateContainer';
 import { ProjectViewStateContainer } from '../../containers/projects/ProjectViewStateContainer';
@@ -31,10 +35,28 @@ export const Main = ({ className, ...props }) => {
   return (
     <main className={mainClassNames} {...props}>
       <Switch>
-        <Route exact path="/" component={DashboardViewStateContainer} />
-        <Route exact path="/projects" component={ListProjectsViewStateContainer} />
-        <Route exact path="/projects/:projectName" component={ProjectViewStateContainer} />
+        <Route exact path="/" render={renderDashboardViewStateContainer} />
+        <Route exact path="/projects" render={renderListProjectsViewStateContainer} />
+        <Route exact path="/projects/:projectName" render={renderProjectViewStateContainer} />
       </Switch>
     </main>
   );
 };
+
+const renderDashboardViewStateContainer = () => (
+  <DashboardViewStateContainer>
+    {(stateId, dashboard) => <DashboardView stateId={stateId} dashboard={dashboard} />}
+  </DashboardViewStateContainer>
+);
+
+const renderListProjectsViewStateContainer = () => (
+  <ListProjectsViewStateContainer>
+    {(stateId, projects) => <ListProjectsView stateId={stateId} projects={projects} />}
+  </ListProjectsViewStateContainer>
+);
+
+const renderProjectViewStateContainer = () => (
+  <ProjectViewStateContainer>
+    {(stateId, project) => <ProjectView stateId={stateId} project={project} />}
+  </ProjectViewStateContainer>
+);

--- a/src/components/projects/listprojects/ListProjectsView.js
+++ b/src/components/projects/listprojects/ListProjectsView.js
@@ -8,17 +8,51 @@
  *******************************************************************************/
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { classNames } from '../../../common/classnames';
 
+import { Loading } from '../../loading/Loading';
+
 import { ProjectsListCard } from '../ProjectsListCard';
 
+import { LOADING__STATE, PROJECTS_LOADED__STATE } from './ListProjectsViewFiniteStateMachine';
+
 const LIST_PROJECTS_VIEW__CLASS_NAMES = 'listprojectsview';
+
+const propTypes = {
+  stateId: PropTypes.string.isRequired
+};
 
 /**
  * The ListProjectsView component is used to display the list of all the projects.
  */
-export const ListProjectsView = ({ className, projects, ...props }) => {
+export const ListProjectsView = ({ className, stateId, projects, ...props }) => {
+  switch (stateId) {
+    case LOADING__STATE:
+      return renderLoadingState(className, props);
+    case PROJECTS_LOADED__STATE:
+      return renderProjectsLoadedState(className, projects, props);
+    default:
+      return renderLoadingState(className, props);
+  }
+};
+ListProjectsView.propTypes = propTypes;
+
+/**
+ * Renders the loading state of the projects list.
+ * @param {*} className The class name of the projects list
+ * @param {*} props The properties of the component
+ */
+const renderLoadingState = (className, props) => <Loading className={className} {...props} />;
+
+/**
+ * Renders the projects loaded.
+ * @param {*} className The class name of the projects list
+ * @param {*} projects The projects to be displayed
+ * @param {*} props The properties of the component
+ */
+const renderProjectsLoadedState = (className, projects, props) => {
   const listProjectsViewClassNames = classNames(LIST_PROJECTS_VIEW__CLASS_NAMES, className);
   return (
     <div className={listProjectsViewClassNames}>

--- a/src/components/projects/project/ProjectView.js
+++ b/src/components/projects/project/ProjectView.js
@@ -8,23 +8,49 @@
  *******************************************************************************/
 
 import React from 'react';
+import PropTypes from 'prop-types';
+
+import { classNames } from '../../../common/classnames';
+
+import { Loading } from '../../loading/Loading';
 
 import { ProjectHeaderCard } from '../ProjectHeaderCard';
 import { ProjectRepresentationsListCard } from '../ProjectRepresentationsListCard';
 import { ProjectSemanticResourcesListCard } from '../ProjectSemanticResourcesListCard';
 
+import { LOADING__STATE, PROJECT_LOADED__STATE } from './ProjectViewFiniteStateMachine';
+
 import './ProjectView.css';
+
+const propTypes = {
+  stateId: PropTypes.string
+};
+
+/**
+ * The ProjectView is used to display and manipulate a project.
+ */
+export const ProjectView = ({ className, stateId, error, project, ...props }) => {
+  switch (stateId) {
+    case LOADING__STATE:
+      return renderLoadingState(className, props);
+    case PROJECT_LOADED__STATE:
+      return renderProjectLoadedState(className, project, props);
+    default:
+      return renderLoadingState(className, props);
+  }
+};
+ProjectView.propTypes = propTypes;
+
+const renderLoadingState = (className, props) => <Loading className={className} {...props} />;
 
 const PROJECT_VIEW__CLASS_NAMES = 'projectview';
 const PROJECT_VIEW_MAIN__CLASS_NAMES = 'projectview-main';
 const PROJECT_VIEW_DETAILS__CLASS_NAMES = 'projectview-details';
 
-/**
- * The ProjectView is used to display and manipulate a project.
- */
-export const ProjectView = ({ className, project, ...props }) => {
+const renderProjectLoadedState = (className, project, props) => {
+  const projectViewClassNames = classNames(PROJECT_VIEW__CLASS_NAMES, className);
   return (
-    <div className={PROJECT_VIEW__CLASS_NAMES}>
+    <div className={projectViewClassNames}>
       <ProjectHeaderCard name={project.name} />
       <div className={PROJECT_VIEW_MAIN__CLASS_NAMES}>
         <div className={PROJECT_VIEW_DETAILS__CLASS_NAMES}>

--- a/src/containers/dashboard/DashboardViewStateContainer.js
+++ b/src/containers/dashboard/DashboardViewStateContainer.js
@@ -7,9 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-import React, { Component } from 'react';
-
-import { DashboardView } from '../../components/dashboard/DashboardView';
+import { Component } from 'react';
 
 import { actionCreator, dispatcher } from '../../components/dashboard/DashboardViewDispatcher';
 
@@ -39,8 +37,9 @@ export class DashboardViewStateContainer extends Component {
   }
 
   render() {
-    const { dashboard } = this.state;
+    const { children, render = children } = this.props;
+    const { stateId, dashboard } = this.state;
 
-    return <DashboardView dashboard={dashboard} />;
+    return render(stateId, dashboard);
   }
 }

--- a/src/containers/projects/ListProjectsViewStateContainer.js
+++ b/src/containers/projects/ListProjectsViewStateContainer.js
@@ -7,9 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-import React, { Component } from 'react';
-
-import { ListProjectsView } from '../../components/projects/listprojects/ListProjectsView';
+import { Component } from 'react';
 
 import {
   actionCreator,
@@ -42,8 +40,9 @@ export class ListProjectsViewStateContainer extends Component {
   }
 
   render() {
-    const { projects } = this.state;
+    const { children, render = children } = this.props;
+    const { stateId, projects } = this.state;
 
-    return <ListProjectsView projects={projects} />;
+    return render(stateId, projects);
   }
 }

--- a/src/containers/projects/ProjectViewStateContainer.js
+++ b/src/containers/projects/ProjectViewStateContainer.js
@@ -7,10 +7,8 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { withRouter } from 'react-router-dom';
-
-import { ProjectView } from '../../components/projects/project/ProjectView';
 
 import { actionCreator, dispatcher } from '../../components/projects/project/ProjectViewDispatcher';
 
@@ -45,12 +43,10 @@ class ProjectViewStateContainerWithoutRouter extends Component {
   }
 
   render() {
-    const { project } = this.state;
+    const { children, render = children } = this.props;
+    const { stateId, project } = this.state;
 
-    if (!project) {
-      return <p>Loading</p>;
-    }
-    return <ProjectView project={project} {...this.props} />;
+    return render(stateId, project);
   }
 }
 export const ProjectViewStateContainer = withRouter(ProjectViewStateContainerWithoutRouter);


### PR DESCRIPTION
This commit will modify the various state container components to remove
the rendering logic. This way our stateful components are separated in
three parts. First the behavior in the reducers. Second, the state and
its lifecycle in the state containers and finally the rendering in the
view components.

The state containers and the rendering components are connected by the
Main component now. The rendering components are now way easier to
understand since they can leverage the stateId property in order to show
the various state of the user interface. The whole can thus be reused
much more easily.

Bug: https://github.com/eclipse/sirius-components/issues/11
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non*breaking change which fixes an issue)
* [ ] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] Continuous integration improvement