### PR TITLE
Update the dashboard will additional data

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -60,6 +60,7 @@
   --fontSize-l: 20px;
   --fontSize-xl: 28px;
   --fontSize-xxl: 34px;
+  --fontSize-xxxl: 64px;
 
   --fontWeight-light: 300;
   --fontWeight-regular: 400;

--- a/src/components/dashboard/DashboardView.css
+++ b/src/components/dashboard/DashboardView.css
@@ -7,6 +7,35 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
+.dashboardview {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: min-content min-content;
+  grid-row-gap: var(--layoutDimension-l);
+}
+
+.dashboardview .info {
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-column-gap: var(--layoutDimension-l);
+}
+
+.projectsinfo .card-body {
+  background-color: var(--blue);
+  color: var(--white);
+}
+
+.viewpointsinfo .card-body {
+  background-color: var(--orange);
+  color: var(--white);
+}
+
+.metamodelsinfo .card-body {
+  background-color: var(--purple);
+  color: var(--white);
+}
+
 .dashboardview .projects-body {
   display: grid;
   grid-template-rows: repeat(auto-fill, minmax(100px, 1fr));

--- a/src/components/dashboard/DashboardView.js
+++ b/src/components/dashboard/DashboardView.js
@@ -14,6 +14,7 @@ import { classNames } from '../../common/classnames';
 import { UNSUPPORTED_STATE } from '../../common/errors';
 
 import { ErrorCard } from '../error/ErrorCard';
+import { InfoCard } from '../info/InfoCard';
 import { Loading } from '../loading/Loading';
 import { ProjectSummaryCard } from '../projects/ProjectSummaryCard';
 
@@ -71,6 +72,10 @@ const renderErrorState = (className, error, props) => (
 );
 
 const DASHBOARD_VIEW__CLASS_NAMES = 'dashboardview';
+const INFO__CLASS_NAMES = 'info';
+const PROJECTS_INFO__CLASS_NAMES = 'projectsinfo';
+const VIEWPOINTS_INFO__CLASS_NAMES = 'viewpointsinfo';
+const METAMODELS_INFO__CLASS_NAMES = 'metamodelsinfo';
 const PROJECTS__CLASS_NAMES = 'projects';
 const PROJECTS_BODY__CLASS_NAMES = 'projects-body';
 
@@ -82,8 +87,28 @@ const PROJECTS_BODY__CLASS_NAMES = 'projects-body';
  */
 const renderDashboardLoadedState = (className, dashboard, props) => {
   const dashboardViewClassNames = classNames(DASHBOARD_VIEW__CLASS_NAMES, className);
+
+  const { projectsCount, viewpointsCount, metamodelsCount } = dashboard;
+
   return (
     <div className={dashboardViewClassNames} {...props}>
+      <div className={INFO__CLASS_NAMES}>
+        <InfoCard
+          className={PROJECTS_INFO__CLASS_NAMES}
+          title={projectsCount.toString()}
+          message={'Projects'}
+        />
+        <InfoCard
+          className={VIEWPOINTS_INFO__CLASS_NAMES}
+          title={viewpointsCount.toString()}
+          message={'Viewpoints'}
+        />
+        <InfoCard
+          className={METAMODELS_INFO__CLASS_NAMES}
+          title={metamodelsCount.toString()}
+          message={'Metamodels'}
+        />
+      </div>
       <div className={PROJECTS__CLASS_NAMES}>
         <div className={PROJECTS_BODY__CLASS_NAMES}>
           {dashboard.projects.map(project => (

--- a/src/components/dashboard/__tests__/DashboardView.test.js
+++ b/src/components/dashboard/__tests__/DashboardView.test.js
@@ -26,7 +26,12 @@ describe('DashboardView', () => {
       message: 'Please contact the administrator to try to find a solution',
       code: 500
     };
-    const dashboard = { projects: [] };
+    const dashboard = {
+      projectsCount: '0',
+      viewpointsCount: '27',
+      metamodelsCount: '132',
+      projects: []
+    };
     const dashboardComponent = Renderer.create(
       <MemoryRouter initialEntries={['/']}>
         <DashboardView stateId={ERROR__STATE} error={error} dashboard={dashboard} />
@@ -36,7 +41,12 @@ describe('DashboardView', () => {
   });
 
   it('renders an error card for an unsupported state', () => {
-    const dashboard = { projects: [] };
+    const dashboard = {
+      projectsCount: '0',
+      viewpointsCount: '27',
+      metamodelsCount: '132',
+      projects: []
+    };
     const dashboardComponent = Renderer.create(
       <MemoryRouter initialEntries={['/']}>
         <DashboardView stateId={INITIAL__STATE} error={null} dashboard={dashboard} />
@@ -46,7 +56,12 @@ describe('DashboardView', () => {
   });
 
   it('renders a loading indicator during the loading', () => {
-    const dashboard = { projects: [] };
+    const dashboard = {
+      projectsCount: '0',
+      viewpointsCount: '27',
+      metamodelsCount: '132',
+      projects: []
+    };
     const dashboardComponent = Renderer.create(
       <MemoryRouter initialEntries={['/']}>
         <DashboardView stateId={LOADING__STATE} error={null} dashboard={dashboard} />
@@ -57,7 +72,12 @@ describe('DashboardView', () => {
 
   it('renders the projects', () => {
     const projects = [{ name: 'First Project' }, { name: 'Second Project' }];
-    const dashboard = { projects };
+    const dashboard = {
+      projectsCount: '0',
+      viewpointsCount: '27',
+      metamodelsCount: '132',
+      projects
+    };
     const dashboardComponent = Renderer.create(
       <MemoryRouter initialEntries={['/']}>
         <DashboardView stateId={DASHBOARD_LOADED__STATE} error={null} dashboard={dashboard} />

--- a/src/components/dashboard/__tests__/__snapshots__/DashboardView.test.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/DashboardView.test.js.snap
@@ -51,6 +51,64 @@ exports[`DashboardView renders the projects 1`] = `
   className="dashboardview"
 >
   <div
+    className="info"
+  >
+    <div
+      className="card infocard projectsinfo"
+    >
+      <div
+        className="card-body"
+      >
+        <h1
+          className="infocard-title"
+        >
+          0
+        </h1>
+        <p
+          className="infocard-message"
+        >
+          Projects
+        </p>
+      </div>
+    </div>
+    <div
+      className="card infocard viewpointsinfo"
+    >
+      <div
+        className="card-body"
+      >
+        <h1
+          className="infocard-title"
+        >
+          27
+        </h1>
+        <p
+          className="infocard-message"
+        >
+          Viewpoints
+        </p>
+      </div>
+    </div>
+    <div
+      className="card infocard metamodelsinfo"
+    >
+      <div
+        className="card-body"
+      >
+        <h1
+          className="infocard-title"
+        >
+          132
+        </h1>
+        <p
+          className="infocard-message"
+        >
+          Metamodels
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
     className="projects"
   >
     <div

--- a/src/components/info/InfoCard.css
+++ b/src/components/info/InfoCard.css
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+.infocard .card-body {
+  display: grid;
+  grid-template-rows: min-content min-content;
+  grid-row-gap: var(--layoutDimension-m);
+  padding: var(--layoutDimension-l);
+}
+
+.infocard-title {
+  text-align: center;
+  font-size: var(--fontSize-xxxl);
+  font-weight: var(--fontWeight-bold);
+}
+
+.infocard-message {
+  text-align: center;
+  font-size: var(--fontSize-l);
+}

--- a/src/components/info/InfoCard.js
+++ b/src/components/info/InfoCard.js
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { classNames } from '../../common/classnames';
+
+import { Card, Body } from '../cards/Card';
+
+import './InfoCard.css';
+
+const propTypes = {
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string
+};
+
+const INFOCARD__CLASS_NAMES = 'infocard';
+const INFOCARD_TITLE__CLASS_NAMES = 'infocard-title';
+const INFOCARD_MESSAGE__CLASS_NAMES = 'infocard-message';
+
+/**
+ * The InfoCard component is ued to display some information with a catchy card.
+ */
+export const InfoCard = ({ className, title, message, ...props }) => {
+  const infoCardClassNames = classNames(INFOCARD__CLASS_NAMES, className);
+  return (
+    <Card {...props} className={infoCardClassNames}>
+      <Body>
+        <h1 className={INFOCARD_TITLE__CLASS_NAMES}>{title}</h1>
+        <p className={INFOCARD_MESSAGE__CLASS_NAMES}>{message}</p>
+      </Body>
+    </Card>
+  );
+};
+InfoCard.propTypes = propTypes;

--- a/src/components/info/__tests__/InfoCard.test.js
+++ b/src/components/info/__tests__/InfoCard.test.js
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Obeo and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2
+ * which accompanies this distribution and is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *******************************************************************************/
+
+import React from 'react';
+import Renderer from 'react-test-renderer';
+
+import { InfoCard } from '../InfoCard';
+
+describe('InfoCard', () => {
+  it('renders an info card', () => {
+    const infoCard = Renderer.create(<InfoCard title="42" message="Projects" />);
+    expect(infoCard.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/components/info/__tests__/__snapshots__/InfoCard.test.js.snap
+++ b/src/components/info/__tests__/__snapshots__/InfoCard.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InfoCard renders an info card 1`] = `
+<div
+  className="card infocard"
+>
+  <div
+    className="card-body"
+  >
+    <h1
+      className="infocard-title"
+    >
+      42
+    </h1>
+    <p
+      className="infocard-message"
+    >
+      Projects
+    </p>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This commit will add new cards to the dashboard in order to display some
global information regarding the server. It will thus show the number of
projects available along with the number of viewpoints and metamodels.

The layout of the dashboard has been updated with the introduction of a
new kind of card, the InfoCard.

Bug: https://github.com/eclipse/sirius-components/issues/28
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non*breaking change which fixes an issue)
* [x] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] Continuous integration improvement