### PR TITLE
Improve card components' layout

### DIFF
--- a/src/components/blank/BlankCard.css
+++ b/src/components/blank/BlankCard.css
@@ -7,13 +7,13 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-.blankcard .card-body {
+.blankcard {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: var(--layoutDimension-l);
 }
 
-.blankcard .card-body .title-l {
+.blankcard .title-l {
   margin-bottom: var(--layoutDimension-m);
 }

--- a/src/components/blank/BlankCard.js
+++ b/src/components/blank/BlankCard.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Body, Card } from '../cards/Card';
+import { Card } from '../cards/Card';
 
 import './BlankCard.css';
 
@@ -30,10 +30,8 @@ export const BlankCard = ({ className, title, message, ...props }) => {
   const blankCardClassNames = classNames(BLANKCARD__CLASS_NAMES, className);
   return (
     <Card {...props} className={blankCardClassNames}>
-      <Body>
-        <h1 className={BLANKCARD_TITLE__CLASS_NAMES}>{title}</h1>
-        <p>{message}</p>
-      </Body>
+      <h1 className={BLANKCARD_TITLE__CLASS_NAMES}>{title}</h1>
+      <p>{message}</p>
     </Card>
   );
 };

--- a/src/components/blank/__tests__/__snapshots__/BlankCard.test.js.snap
+++ b/src/components/blank/__tests__/__snapshots__/BlankCard.test.js.snap
@@ -4,17 +4,13 @@ exports[`BlankCard renders a blank card 1`] = `
 <div
   className="card blankcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      Nothing to see here
-    </h1>
-    <p>
-      You should create new elements to see them here
-    </p>
-  </div>
+    Nothing to see here
+  </h1>
+  <p>
+    You should create new elements to see them here
+  </p>
 </div>
 `;

--- a/src/components/cards/Card.css
+++ b/src/components/cards/Card.css
@@ -13,14 +13,26 @@
   border-radius: var(--borderRadius-small);
 }
 
-.card-header {
-  padding: var(--layoutDimension-m);
-}
-
-.card-title {
+.card-herotitle,
+.card-primarytitle,
+.card-secondarytitle {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.card-herotitle {
+  padding: var(--layoutDimension-m) var(--layoutDimension-m) var(--layoutDimension-l)
+    var(--layoutDimension-m);
+}
+
+.card-primarytitle {
+  padding: var(--layoutDimension-m) var(--layoutDimension-m);
+}
+
+.card-secondarytitle {
+  padding: var(--layoutDimension-m) var(--layoutDimension-m) var(--layoutDimension-s)
+    var(--layoutDimension-m);
 }
 
 .card-divider {

--- a/src/components/cards/Card.js
+++ b/src/components/cards/Card.js
@@ -28,51 +28,69 @@ export const Card = ({ className, ...props }) => {
   );
 };
 
-const CARD_HEADER__CLASS_NAMES = 'card-header';
+const CARD_HEROTITLE__CLASS_NAMES = 'card-herotitle title-xl';
 
-/**
- * The Header component is used to display a header in the Card.
- */
-export const Header = ({ className, ...props }) => {
-  const headerClassNames = classNames(CARD_HEADER__CLASS_NAMES, className);
-  return (
-    <div className={headerClassNames} {...props}>
-      {props.children}
-    </div>
-  );
-};
-
-/** The large title kind. */
-export const TITLE_LARGE__KIND = 'large';
-
-const CARD_TITLE__CLASS_NAMES = 'card-title';
-const CARD_TITLE_REGULAR__CLASS_NAMES = 'title-l';
-const CARD_TITLE_LARGE__CLASS_NAMES = 'title-xl';
-
-const titlePropTypes = {
-  kind: PropTypes.string
-};
-const titleDefaultProps = {
-  kind: ''
+const heroTitlePropTypes = {
+  label: PropTypes.string.isRequired
 };
 
 /**
- * The Title of the Card, to be used inside a Header.
+ * The Hero Title of the Card.
  */
-export const Title = ({ className, kind, ...props }) => {
-  let additionalClassNames = CARD_TITLE_REGULAR__CLASS_NAMES;
-  if (kind === TITLE_LARGE__KIND) {
-    additionalClassNames = CARD_TITLE_LARGE__CLASS_NAMES;
-  }
-  const titleClassNames = classNames(CARD_TITLE__CLASS_NAMES, additionalClassNames, className);
+export const HeroTitle = ({ className, label, ...props }) => {
+  const heroTitleClassNames = classNames(CARD_HEROTITLE__CLASS_NAMES, className);
   return (
-    <h1 className={titleClassNames} {...props}>
-      {props.children}
+    <h1 className={heroTitleClassNames} {...props}>
+      {label}
     </h1>
   );
 };
-Title.propTypes = titlePropTypes;
-Title.defaultProps = titleDefaultProps;
+HeroTitle.propTypes = heroTitlePropTypes;
+
+const CARD_PRIMARYTITLE__CLASS_NAMES = 'card-primarytitle title-l';
+
+const primaryTitlePropTypes = {
+  label: PropTypes.string.isRequired
+};
+
+/**
+ * The Primary Title of the Card.
+ */
+export const PrimaryTitle = ({ className, label, ...props }) => {
+  const primaryTitleClassNames = classNames(CARD_PRIMARYTITLE__CLASS_NAMES, className);
+  return (
+    <h2 className={primaryTitleClassNames} {...props}>
+      {label}
+    </h2>
+  );
+};
+PrimaryTitle.propTypes = primaryTitlePropTypes;
+
+const CARD_SECONDARYTITLE__CLASS_NAMES = 'card-secondarytitle title-m';
+
+const secondaryTitlePropTypes = {
+  label: PropTypes.string.isRequired
+};
+
+/**
+ * The Secondary Title of the card.
+ */
+export const SecondaryTitle = ({ className, label, ...props }) => {
+  const secondaryTitleClassNames = classNames(CARD_SECONDARYTITLE__CLASS_NAMES, className);
+  return (
+    <h3 className={secondaryTitleClassNames} {...props}>
+      {label}
+    </h3>
+  );
+};
+SecondaryTitle.propTypes = secondaryTitlePropTypes;
+
+const CARD_TEXT__CLASS_NAMES = 'card-text body-s';
+
+export const Text = ({ className, ...props }) => {
+  const textClassNames = classNames(CARD_TEXT__CLASS_NAMES, className);
+  return <div className={textClassNames} {...props} />;
+};
 
 const CARD_DIVIDER__CLASS_NAMES = 'card-divider';
 
@@ -85,29 +103,15 @@ export const Divider = ({ className, ...props }) => {
   return <div className={dividerClassNames} {...props} />;
 };
 
-const CARD_BODY__CLASS_NAMES = 'card-body';
+const CARD_ACTIONS__CLASS_NAMES = 'card-actions';
 
 /**
- * The Body is the main part of the Card where most of its content will be located.
+ * The Actions component is used to display some actions or links.
  */
-export const Body = ({ className, ...props }) => {
-  const bodyClassNames = classNames(CARD_BODY__CLASS_NAMES, className);
+export const Actions = ({ className, ...props }) => {
+  const actionsClassNames = classNames(CARD_ACTIONS__CLASS_NAMES, className);
   return (
-    <div className={bodyClassNames} {...props}>
-      {props.children}
-    </div>
-  );
-};
-
-const CARD_FOOTER__CLASS_NAMES = 'card-footer';
-
-/**
- * The Footer is used to display some actions or links.
- */
-export const Footer = ({ className, ...props }) => {
-  const footerClassNames = classNames(CARD_FOOTER__CLASS_NAMES, className);
-  return (
-    <div className={footerClassNames} {...props}>
+    <div className={actionsClassNames} {...props}>
       {props.children}
     </div>
   );

--- a/src/components/cards/README.adoc
+++ b/src/components/cards/README.adoc
@@ -1,0 +1,41 @@
+= Card
+
+== Usage
+
+Cards are used to display a set of properties of an element.
+A card can contain various subcomponents with various layouts and actions.
+If you want to display a large set of cards with a small amount of information, a list may be more relevant.
+
+== Behavior
+
+Cards may be available in various width.
+Once on screen, a card will have a constant width but its height may change.
+Cards could be collapsed to reduce the amount of information displayed.
+A collection of card may be filterable and/or sortable.
+
+== Content
+
+Cards provide a bird eye view of complex information.
+Do not try to fill cards with more information than necessary.
+
+
+== Actions
+
+The card itself can be an action.
+As such, it can act as a link to another page.
+Actions can be added to the card thanks to icons, text or buttons.
+Do not add more than two button-based actions to the card.
+
+== Specification
+
+Cards can be created by mixin various content blocks including:
+
+* Hero Title
+* Primary Title
+* Secondary Title
+* Text
+* Actions
+* List components
+* TabBar component
+
+Those components can be combined in various ways.

--- a/src/components/cards/__tests__/Card.test.js
+++ b/src/components/cards/__tests__/Card.test.js
@@ -10,7 +10,7 @@
 import React from 'react';
 import Renderer from 'react-test-renderer';
 
-import { Body, Card, Divider, Header, Title } from '../Card';
+import { Card, Divider, PrimaryTitle } from '../Card';
 
 describe('Card', () => {
   it('renders an empty card', () => {
@@ -18,26 +18,20 @@ describe('Card', () => {
     expect(card.toJSON()).toMatchSnapshot();
   });
 
-  it('renders a card with a header and a body', () => {
+  it('renders a card with a primary title', () => {
     const card = Renderer.create(
       <Card>
-        <Header>
-          <Title>Card Title</Title>
-        </Header>
-        <Body />
+        <PrimaryTitle label="Card Title" />
       </Card>
     );
     expect(card.toJSON()).toMatchSnapshot();
   });
 
-  it('renders a card with a divider between the header and body', () => {
+  it('renders a card with a primary title and a divider', () => {
     const card = Renderer.create(
       <Card>
-        <Header>
-          <Title>Card Title</Title>
-        </Header>
+        <PrimaryTitle label="Card Title" />
         <Divider />
-        <Body />
       </Card>
     );
     expect(card.toJSON()).toMatchSnapshot();

--- a/src/components/cards/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/components/cards/__tests__/__snapshots__/Card.test.js.snap
@@ -1,42 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Card renders a card with a divider between the header and body 1`] = `
+exports[`Card renders a card with a primary title 1`] = `
 <div
   className="card"
 >
-  <div
-    className="card-header"
+  <h2
+    className="card-primarytitle title-l"
   >
-    <h1
-      className="card-title title-l"
-    >
-      Card Title
-    </h1>
-  </div>
-  <div
-    className="card-divider"
-  />
-  <div
-    className="card-body"
-  />
+    Card Title
+  </h2>
 </div>
 `;
 
-exports[`Card renders a card with a header and a body 1`] = `
+exports[`Card renders a card with a primary title and a divider 1`] = `
 <div
   className="card"
 >
-  <div
-    className="card-header"
+  <h2
+    className="card-primarytitle title-l"
   >
-    <h1
-      className="card-title title-l"
-    >
-      Card Title
-    </h1>
-  </div>
+    Card Title
+  </h2>
   <div
-    className="card-body"
+    className="card-divider"
   />
 </div>
 `;

--- a/src/components/dashboard/DashboardView.css
+++ b/src/components/dashboard/DashboardView.css
@@ -20,24 +20,18 @@
   grid-template-columns: 1fr 1fr 1fr;
   grid-column-gap: var(--layoutDimension-l);
 }
-.newprojectinfo .card-body:hover {
-  color: var(--light-blue);
-}
-.newprojectinfo .card-body:active {
-  color: var(--dark-blue);
-}
 
-.projectsinfo .card-body {
+.projectsinfo {
   background-color: var(--blue);
   color: var(--white);
 }
 
-.viewpointsinfo .card-body {
+.viewpointsinfo {
   background-color: var(--orange);
   color: var(--white);
 }
 
-.metamodelsinfo .card-body {
+.metamodelsinfo {
   background-color: var(--purple);
   color: var(--white);
 }

--- a/src/components/dashboard/DashboardView.js
+++ b/src/components/dashboard/DashboardView.js
@@ -8,6 +8,7 @@
  *******************************************************************************/
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
@@ -112,12 +113,14 @@ const renderDashboardLoadedState = (className, dashboard, props) => {
       </div>
       <div className={PROJECTS__CLASS_NAMES}>
         <div className={PROJECTS_BODY__CLASS_NAMES}>
-          <InfoCard
-            className={NEWPROJECT_INFO__CLASS_NAMES}
-            title="+"
-            message="New Project"
-            to="/newproject"
-          />
+          <Link to="/newproject">
+            <InfoCard
+              className={NEWPROJECT_INFO__CLASS_NAMES}
+              title="+"
+              message="New Project"
+              to=""
+            />
+          </Link>
           {dashboard.projects.map(project => (
             <ProjectSummaryCard key={project.name} project={project} />
           ))}

--- a/src/components/dashboard/__tests__/__snapshots__/DashboardView.test.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/DashboardView.test.js.snap
@@ -12,18 +12,14 @@ exports[`DashboardView renders an error card for an error 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      An error has occurred
-    </h1>
-    <p>
-      Please contact the administrator to try to find a solution (code: 500)
-    </p>
-  </div>
+    An error has occurred
+  </h1>
+  <p>
+    Please contact the administrator to try to find a solution (code: 500)
+  </p>
 </div>
 `;
 
@@ -31,18 +27,14 @@ exports[`DashboardView renders an error card for an unsupported state 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      The dashboard is in an unsupported state: INITIAL__STATE
-    </h1>
-    <p>
-      Contact your administrator to find a suitable solution (code: 1001)
-    </p>
-  </div>
+    The dashboard is in an unsupported state: INITIAL__STATE
+  </h1>
+  <p>
+    Contact your administrator to find a suitable solution (code: 1001)
+  </p>
 </div>
 `;
 
@@ -56,56 +48,44 @@ exports[`DashboardView renders the projects 1`] = `
     <div
       className="card infocard projectsinfo"
     >
-      <div
-        className="card-body"
+      <h1
+        className="infocard-title"
       >
-        <h1
-          className="infocard-title"
-        >
-          0
-        </h1>
-        <p
-          className="infocard-message"
-        >
-          Projects
-        </p>
-      </div>
+        0
+      </h1>
+      <p
+        className="infocard-message"
+      >
+        Projects
+      </p>
     </div>
     <div
       className="card infocard viewpointsinfo"
     >
-      <div
-        className="card-body"
+      <h1
+        className="infocard-title"
       >
-        <h1
-          className="infocard-title"
-        >
-          27
-        </h1>
-        <p
-          className="infocard-message"
-        >
-          Viewpoints
-        </p>
-      </div>
+        27
+      </h1>
+      <p
+        className="infocard-message"
+      >
+        Viewpoints
+      </p>
     </div>
     <div
       className="card infocard metamodelsinfo"
     >
-      <div
-        className="card-body"
+      <h1
+        className="infocard-title"
       >
-        <h1
-          className="infocard-title"
-        >
-          132
-        </h1>
-        <p
-          className="infocard-message"
-        >
-          Metamodels
-        </p>
-      </div>
+        132
+      </h1>
+      <p
+        className="infocard-message"
+      >
+        Metamodels
+      </p>
     </div>
   </div>
   <div
@@ -114,64 +94,53 @@ exports[`DashboardView renders the projects 1`] = `
     <div
       className="projects-body"
     >
+      <a
+        href="/newproject"
+        onClick={[Function]}
+      >
+        <div
+          className="card infocard newprojectinfo"
+          to=""
+        >
+          <h1
+            className="infocard-title"
+          >
+            +
+          </h1>
+          <p
+            className="infocard-message"
+          >
+            New Project
+          </p>
+        </div>
+      </a>
       <div
-        className="card infocard newprojectinfo"
+        className="card projectsummarycard"
       >
         <a
-          href="/newproject"
+          href="/projects/First Project"
           onClick={[Function]}
         >
-          <div
-            className="card-body"
+          <h2
+            className="card-primarytitle title-l"
           >
-            <h1
-              className="infocard-title"
-            >
-              +
-            </h1>
-            <p
-              className="infocard-message"
-            >
-              New Project
-            </p>
-          </div>
+            First Project
+          </h2>
         </a>
       </div>
       <div
         className="card projectsummarycard"
       >
-        <div
-          className="card-header"
+        <a
+          href="/projects/Second Project"
+          onClick={[Function]}
         >
-          <a
-            href="/projects/First Project"
-            onClick={[Function]}
+          <h2
+            className="card-primarytitle title-l"
           >
-            <h1
-              className="card-title title-l"
-            >
-              First Project
-            </h1>
-          </a>
-        </div>
-      </div>
-      <div
-        className="card projectsummarycard"
-      >
-        <div
-          className="card-header"
-        >
-          <a
-            href="/projects/Second Project"
-            onClick={[Function]}
-          >
-            <h1
-              className="card-title title-l"
-            >
-              Second Project
-            </h1>
-          </a>
-        </div>
+            Second Project
+          </h2>
+        </a>
       </div>
     </div>
   </div>

--- a/src/components/error/ErrorCard.css
+++ b/src/components/error/ErrorCard.css
@@ -7,13 +7,13 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-.errorcard .card-body {
+.errorcard {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: var(--layoutDimension-l);
 }
 
-.errorcard .card-body .title-l {
+.errorcard .title-l {
   margin-bottom: var(--layoutDimension-m);
 }

--- a/src/components/error/ErrorCard.js
+++ b/src/components/error/ErrorCard.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Body, Card } from '../cards/Card';
+import { Card } from '../cards/Card';
 
 import './ErrorCard.css';
 
@@ -32,10 +32,8 @@ export const ErrorCard = ({ className, code, title, message, ...props }) => {
   const errorCardClassNames = classNames(ERRORCARD__CLASS_NAMES, className);
   return (
     <Card {...props} className={errorCardClassNames}>
-      <Body>
-        <h1 className={ERRORCARD_TITLE__CLASS_NAMES}>{title}</h1>
-        <p>{`${message} (code: ${code})`}</p>
-      </Body>
+      <h1 className={ERRORCARD_TITLE__CLASS_NAMES}>{title}</h1>
+      <p>{`${message} (code: ${code})`}</p>
     </Card>
   );
 };

--- a/src/components/error/__tests__/__snapshots__/ErrorCard.test.js.snap
+++ b/src/components/error/__tests__/__snapshots__/ErrorCard.test.js.snap
@@ -4,17 +4,13 @@ exports[`ErrorCard renders an error card 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      An error has occurred
-    </h1>
-    <p>
-      Please contact your administrator to find out more about this error (code: 500)
-    </p>
-  </div>
+    An error has occurred
+  </h1>
+  <p>
+    Please contact your administrator to find out more about this error (code: 500)
+  </p>
 </div>
 `;

--- a/src/components/form/Form.css
+++ b/src/components/form/Form.css
@@ -25,7 +25,7 @@
   padding: 0 0 var(--layoutDimension-s) 0;
 }
 
-.text {
+.textfield {
   display: block;
   width: 100%;
   font-size: var(--fontSize-s);
@@ -38,14 +38,14 @@
   background-clip: padding-box;
   overflow: visible;
 }
-.text:focus {
+.textfield:focus {
   color: var(--slate);
   background-color: var(--white);
   border-color: var(--blue);
   outline: 0;
   box-shadow: var(--boxShadow-float);
 }
-.text.fielderror {
+.textfield.fielderror {
   border-color: var(--red);
 }
 

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -53,13 +53,13 @@ export const Description = ({ className, ...props }) => {
   return <p className={descriptionClassNames} {...props} />;
 };
 
-const TEXT__CLASS_NAMES = 'text';
+const TEXTFIELD__CLASS_NAMES = 'textfield';
 
 /**
  * The Text widget.
  */
-export const Text = ({ className, ...props }) => {
-  const textClassNames = classNames(TEXT__CLASS_NAMES, className);
+export const TextField = ({ className, ...props }) => {
+  const textClassNames = classNames(TEXTFIELD__CLASS_NAMES, className);
   return <input className={textClassNames} type="text" {...props} />;
 };
 

--- a/src/components/info/InfoCard.css
+++ b/src/components/info/InfoCard.css
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-.infocard .card-body {
+.infocard {
   display: grid;
   grid-template-rows: min-content min-content;
   grid-row-gap: var(--layoutDimension-m);

--- a/src/components/info/InfoCard.js
+++ b/src/components/info/InfoCard.js
@@ -9,11 +9,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
-
 import { classNames } from '../../common/classnames';
 
-import { Card, Body } from '../cards/Card';
+import { Card } from '../cards/Card';
 
 import './InfoCard.css';
 
@@ -29,22 +27,12 @@ const INFOCARD_MESSAGE__CLASS_NAMES = 'infocard-message';
 /**
  * The InfoCard component is used to display some information with a catchy card.
  */
-export const InfoCard = ({ className, title, message, to, ...props }) => {
-  let cardBody = (
-    <Body>
-      <h1 className={INFOCARD_TITLE__CLASS_NAMES}>{title}</h1>
-      <p className={INFOCARD_MESSAGE__CLASS_NAMES}>{message}</p>
-    </Body>
-  );
-
-  if (to) {
-    cardBody = <Link to={to}>{cardBody}</Link>;
-  }
-
+export const InfoCard = ({ className, title, message, ...props }) => {
   const infoCardClassNames = classNames(INFOCARD__CLASS_NAMES, className);
   return (
     <Card {...props} className={infoCardClassNames}>
-      {cardBody}
+      <h1 className={INFOCARD_TITLE__CLASS_NAMES}>{title}</h1>
+      <p className={INFOCARD_MESSAGE__CLASS_NAMES}>{message}</p>
     </Card>
   );
 };

--- a/src/components/info/__tests__/__snapshots__/InfoCard.test.js.snap
+++ b/src/components/info/__tests__/__snapshots__/InfoCard.test.js.snap
@@ -4,19 +4,15 @@ exports[`InfoCard renders an info card 1`] = `
 <div
   className="card infocard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="infocard-title"
   >
-    <h1
-      className="infocard-title"
-    >
-      42
-    </h1>
-    <p
-      className="infocard-message"
-    >
-      Projects
-    </p>
-  </div>
+    42
+  </h1>
+  <p
+    className="infocard-message"
+  >
+    Projects
+  </p>
 </div>
 `;

--- a/src/components/projects/NewProjectCard.js
+++ b/src/components/projects/NewProjectCard.js
@@ -12,7 +12,7 @@ import React from 'react';
 import { classNames } from '../../common/classnames';
 
 import { Button, BUTTON_PRIMARY__KIND } from '../buttons/Button';
-import { Body, Card, Divider, Header, Title } from '../cards/Card';
+import { Card, Divider, PrimaryTitle } from '../cards/Card';
 import {
   ActionGroup,
   Description,
@@ -21,7 +21,7 @@ import {
   Form,
   Field,
   Label,
-  Text
+  TextField
 } from '../form/Form';
 
 const NEWPROJECT_CARD__CLASS_NAMES = 'newprojectcard';
@@ -50,36 +50,32 @@ export const NewProjectCard = ({
 
   return (
     <Card className={newProjectCardClassNames} {...props}>
-      <Header>
-        <Title>New Project</Title>
-      </Header>
+      <PrimaryTitle label="New Project" />
       <Divider />
-      <Body>
-        <Form onSubmit={onSubmit}>
-          <ErrorGroup>{errors.map(error => <Error key={error}>{error}</Error>)}</ErrorGroup>
-          <Field>
-            <Label htmlFor="name">Name</Label>
-            <Description>
-              The name of the project can only contain letters and numbers separated by dots, dashes
-              or underscores.
-            </Description>
-            <Text
-              id="name"
-              name="name"
-              className={nameClassName}
-              placeholder="Enter the name"
-              value={name}
-              onChange={onNameChange}
-            />
-            <ErrorGroup>{nameErrors.map(error => <Error key={error}>{error}</Error>)}</ErrorGroup>
-          </Field>
-          <ActionGroup>
-            <Button kind={BUTTON_PRIMARY__KIND} disabled={!isValid}>
-              Create Project
-            </Button>
-          </ActionGroup>
-        </Form>
-      </Body>
+      <Form onSubmit={onSubmit}>
+        <ErrorGroup>{errors.map(error => <Error key={error}>{error}</Error>)}</ErrorGroup>
+        <Field>
+          <Label htmlFor="name">Name</Label>
+          <Description>
+            The name of the project can only contain letters and numbers separated by dots, dashes
+            or underscores.
+          </Description>
+          <TextField
+            id="name"
+            name="name"
+            className={nameClassName}
+            placeholder="Enter the name"
+            value={name}
+            onChange={onNameChange}
+          />
+          <ErrorGroup>{nameErrors.map(error => <Error key={error}>{error}</Error>)}</ErrorGroup>
+        </Field>
+        <ActionGroup>
+          <Button kind={BUTTON_PRIMARY__KIND} disabled={!isValid}>
+            Create Project
+          </Button>
+        </ActionGroup>
+      </Form>
     </Card>
   );
 };

--- a/src/components/projects/ProjectHeaderCard.js
+++ b/src/components/projects/ProjectHeaderCard.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Card, Header, Title, TITLE_LARGE__KIND } from '../cards/Card';
+import { Card, HeroTitle } from '../cards/Card';
 
 const PROJECT_HEADER_CARD__CLASS_NAMES = 'projectheadercard';
 
@@ -28,9 +28,7 @@ export const ProjectHeaderCard = ({ className, name, ...props }) => {
   const cardClassNames = classNames(PROJECT_HEADER_CARD__CLASS_NAMES, className);
   return (
     <Card className={cardClassNames} {...props}>
-      <Header>
-        <Title kind={TITLE_LARGE__KIND}>{name}</Title>
-      </Header>
+      <HeroTitle label={name} />
     </Card>
   );
 };

--- a/src/components/projects/ProjectRepresentationsListCard.js
+++ b/src/components/projects/ProjectRepresentationsListCard.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Body, Card, Header, Title } from '../cards/Card';
+import { Card, PrimaryTitle } from '../cards/Card';
 import {
   LIST_WITH_HIGHLIGHT__KIND,
   AdditionalText,
@@ -39,21 +39,17 @@ export const ProjectRepresentationsListCard = ({ className, representations, ...
   const cardClassNames = classNames(PROJECT_REPRESENTATIONS_LIST_CARD__CLASS_NAMES, className);
   return (
     <Card className={cardClassNames} {...props}>
-      <Header>
-        <Title>Representations</Title>
-      </Header>
-      <Body>
-        <List kind={LIST_WITH_HIGHLIGHT__KIND}>
-          {representations.map(representation => (
-            <TwoLineTile key={representation.name}>
-              <div>
-                <MainText>{representation.name}</MainText>
-                <AdditionalText>{representation.descriptionName}</AdditionalText>
-              </div>
-            </TwoLineTile>
-          ))}
-        </List>
-      </Body>
+      <PrimaryTitle label="Representations" />
+      <List kind={LIST_WITH_HIGHLIGHT__KIND}>
+        {representations.map(representation => (
+          <TwoLineTile key={representation.name}>
+            <div>
+              <MainText>{representation.name}</MainText>
+              <AdditionalText>{representation.descriptionName}</AdditionalText>
+            </div>
+          </TwoLineTile>
+        ))}
+      </List>
     </Card>
   );
 };

--- a/src/components/projects/ProjectSemanticResourcesListCard.js
+++ b/src/components/projects/ProjectSemanticResourcesListCard.js
@@ -12,10 +12,11 @@ import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Body, Card, Header, Title } from '../cards/Card';
+import { Card, PrimaryTitle } from '../cards/Card';
 import { List, MainText, SingleLineTile, LIST_WITH_HIGHLIGHT__KIND } from '../list/List';
 
 const PROJECT_SEMANTIC_RESOURCES_LIST_CARD__CLASS_NAMES = 'projectsemanticresourceslistcard';
+const SEMANTIC_RESOURCES_SIZE__CLASS_NAMES = 'semanticresources-size caption-s';
 
 const propTypes = {
   semanticResources: PropTypes.array.isRequired
@@ -33,18 +34,15 @@ export const ProjectSemanticResourcesListCard = ({ className, semanticResources,
   const cardClassNames = classNames(PROJECT_SEMANTIC_RESOURCES_LIST_CARD__CLASS_NAMES, className);
   return (
     <Card className={cardClassNames} {...props}>
-      <Header>
-        <Title>Semantic Resources</Title>
-      </Header>
-      <Body>
-        <List kind={LIST_WITH_HIGHLIGHT__KIND}>
-          {semanticResources.map(resource => (
-            <SingleLineTile key={resource.path}>
-              <MainText>{resource.path}</MainText>
-            </SingleLineTile>
-          ))}
-        </List>
-      </Body>
+      <PrimaryTitle label="Semantic Resources" />
+      <List kind={LIST_WITH_HIGHLIGHT__KIND}>
+        {semanticResources.map(resource => (
+          <SingleLineTile key={resource.path}>
+            <MainText>{resource.path}</MainText>
+            <div className={SEMANTIC_RESOURCES_SIZE__CLASS_NAMES}>{resource.size}</div>
+          </SingleLineTile>
+        ))}
+      </List>
     </Card>
   );
 };

--- a/src/components/projects/ProjectSummaryCard.css
+++ b/src/components/projects/ProjectSummaryCard.css
@@ -6,7 +6,3 @@
  * which accompanies this distribution and is available at
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
-
-.projectsummarycard .card-divider {
-  margin-top: var(--layoutDimension-s);
-}

--- a/src/components/projects/ProjectSummaryCard.js
+++ b/src/components/projects/ProjectSummaryCard.js
@@ -11,7 +11,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-import { Card, Header, Title } from '../cards/Card';
+import { Card, PrimaryTitle } from '../cards/Card';
 
 import './ProjectSummaryCard.css';
 
@@ -28,11 +28,9 @@ const propTypes = {
 export const ProjectSummaryCard = ({ project, ...props }) => {
   return (
     <Card className={PROJECT_SUMMARY_CARD__CLASS_NAMES} {...props}>
-      <Header>
-        <Link to={`/projects/${project.name}`}>
-          <Title>{project.name}</Title>
-        </Link>
-      </Header>
+      <Link to={`/projects/${project.name}`}>
+        <PrimaryTitle label={project.name} />
+      </Link>
     </Card>
   );
 };

--- a/src/components/projects/ProjectsListCard.js
+++ b/src/components/projects/ProjectsListCard.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Body, Card, Header, Title } from '../cards/Card';
+import { Card, PrimaryTitle } from '../cards/Card';
 import {
   LIST_WITH_HIGHLIGHT__KIND,
   AdditionalText,
@@ -39,25 +39,21 @@ export const ProjectsListCard = ({ className, projects, ...props }) => {
   const projectsListCardClassNames = classNames(PROJECTS_LIST_CARD__CLASS_NAMES, className);
   return (
     <Card className={projectsListCardClassNames} {...props}>
-      <Header>
-        <Title>Projects</Title>
-      </Header>
-      <Body>
-        <List kind={LIST_WITH_HIGHLIGHT__KIND}>
-          {projects.map(project => {
-            return (
-              <Link to={`projects/${project.name}`} key={project.name}>
-                <TwoLineTile>
-                  <div>
-                    <MainText>{project.name}</MainText>
-                    <AdditionalText>{'Description of the project'}</AdditionalText>
-                  </div>
-                </TwoLineTile>
-              </Link>
-            );
-          })}
-        </List>
-      </Body>
+      <PrimaryTitle label="Projects" />
+      <List kind={LIST_WITH_HIGHLIGHT__KIND}>
+        {projects.map(project => {
+          return (
+            <Link to={`projects/${project.name}`} key={project.name}>
+              <TwoLineTile>
+                <div>
+                  <MainText>{project.name}</MainText>
+                  <AdditionalText>{'Description of the project'}</AdditionalText>
+                </div>
+              </TwoLineTile>
+            </Link>
+          );
+        })}
+      </List>
     </Card>
   );
 };

--- a/src/components/projects/listprojects/__tests__/__snapshots__/ListProjectsView.test.js.snap
+++ b/src/components/projects/listprojects/__tests__/__snapshots__/ListProjectsView.test.js.snap
@@ -4,18 +4,14 @@ exports[`ListProjectsView renders a blank card for an empty list of projects 1`]
 <div
   className="card blankcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      You haven't created any projects yet
-    </h1>
-    <p>
-      Once you start creating new projects, you will be able to see them here
-    </p>
-  </div>
+    You haven't created any projects yet
+  </h1>
+  <p>
+    Once you start creating new projects, you will be able to see them here
+  </p>
 </div>
 `;
 
@@ -31,18 +27,14 @@ exports[`ListProjectsView renders an error card for an error 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      An error has occurred
-    </h1>
-    <p>
-      Please contact the administrator to try to find a solution (code: 500)
-    </p>
-  </div>
+    An error has occurred
+  </h1>
+  <p>
+    Please contact the administrator to try to find a solution (code: 500)
+  </p>
 </div>
 `;
 
@@ -50,18 +42,14 @@ exports[`ListProjectsView renders an error card for an unsupported state 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      The projects list is in an unsupported state: INITIAL__STATE
-    </h1>
-    <p>
-      Contact your administrator to find a suitable solution (code: 1001)
-    </p>
-  </div>
+    The projects list is in an unsupported state: INITIAL__STATE
+  </h1>
+  <p>
+    Contact your administrator to find a suitable solution (code: 1001)
+  </p>
 </div>
 `;
 
@@ -72,65 +60,57 @@ exports[`ListProjectsView renders the projects 1`] = `
   <div
     className="card projectslistcard"
   >
-    <div
-      className="card-header"
+    <h2
+      className="card-primarytitle title-l"
     >
-      <h1
-        className="card-title title-l"
-      >
-        Projects
-      </h1>
-    </div>
-    <div
-      className="card-body"
+      Projects
+    </h2>
+    <ul
+      className="list list--highlighted"
     >
-      <ul
-        className="list list--highlighted"
+      <a
+        href="projects/First Project"
+        onClick={[Function]}
       >
-        <a
-          href="projects/First Project"
-          onClick={[Function]}
+        <li
+          className="tile tile--twoline"
         >
-          <li
-            className="tile tile--twoline"
-          >
-            <div>
-              <h4
-                className="tile-maintext body-s"
-              >
-                First Project
-              </h4>
-              <h5
-                className="tile-additionaltext caption-xs"
-              >
-                Description of the project
-              </h5>
-            </div>
-          </li>
-        </a>
-        <a
-          href="projects/Second Project"
-          onClick={[Function]}
+          <div>
+            <h4
+              className="tile-maintext body-s"
+            >
+              First Project
+            </h4>
+            <h5
+              className="tile-additionaltext caption-xs"
+            >
+              Description of the project
+            </h5>
+          </div>
+        </li>
+      </a>
+      <a
+        href="projects/Second Project"
+        onClick={[Function]}
+      >
+        <li
+          className="tile tile--twoline"
         >
-          <li
-            className="tile tile--twoline"
-          >
-            <div>
-              <h4
-                className="tile-maintext body-s"
-              >
-                Second Project
-              </h4>
-              <h5
-                className="tile-additionaltext caption-xs"
-              >
-                Description of the project
-              </h5>
-            </div>
-          </li>
-        </a>
-      </ul>
-    </div>
+          <div>
+            <h4
+              className="tile-maintext body-s"
+            >
+              Second Project
+            </h4>
+            <h5
+              className="tile-additionaltext caption-xs"
+            >
+              Description of the project
+            </h5>
+          </div>
+        </li>
+      </a>
+    </ul>
   </div>
 </div>
 `;

--- a/src/components/projects/newproject/__tests__/__snapshots__/NewProjectView.test.js.snap
+++ b/src/components/projects/newproject/__tests__/__snapshots__/NewProjectView.test.js.snap
@@ -7,67 +7,59 @@ exports[`NewProjectView renders a card with a form ready to be submitted to crea
   <div
     className="card newprojectcard"
   >
-    <div
-      className="card-header"
+    <h2
+      className="card-primarytitle title-l"
     >
-      <h1
-        className="card-title title-l"
-      >
-        New Project
-      </h1>
-    </div>
+      New Project
+    </h2>
     <div
       className="card-divider"
     />
-    <div
-      className="card-body"
+    <form
+      className="form"
+      onSubmit={[Function]}
     >
-      <form
-        className="form"
-        onSubmit={[Function]}
+      <div
+        className="errorgroup"
+      />
+      <div
+        className="field"
       >
+        <label
+          className="label body-l"
+          htmlFor="name"
+        >
+          Name
+        </label>
+        <p
+          className="description caption-m"
+        >
+          The name of the project can only contain letters and numbers separated by dots, dashes or underscores.
+        </p>
+        <input
+          className="textfield"
+          id="name"
+          name="name"
+          onChange={[Function]}
+          placeholder="Enter the name"
+          type="text"
+          value="sirius"
+        />
         <div
           className="errorgroup"
         />
-        <div
-          className="field"
+      </div>
+      <div
+        className="actiongroup"
+      >
+        <button
+          className="button button--primary"
+          disabled={false}
         >
-          <label
-            className="label body-l"
-            htmlFor="name"
-          >
-            Name
-          </label>
-          <p
-            className="description caption-m"
-          >
-            The name of the project can only contain letters and numbers separated by dots, dashes or underscores.
-          </p>
-          <input
-            className="text"
-            id="name"
-            name="name"
-            onChange={[Function]}
-            placeholder="Enter the name"
-            type="text"
-            value="sirius"
-          />
-          <div
-            className="errorgroup"
-          />
-        </div>
-        <div
-          className="actiongroup"
-        >
-          <button
-            className="button button--primary"
-            disabled={false}
-          >
-            Create Project
-          </button>
-        </div>
-      </form>
-    </div>
+          Create Project
+        </button>
+      </div>
+    </form>
   </div>
 </div>
 `;
@@ -79,67 +71,59 @@ exports[`NewProjectView renders a card with a unsubmittable form to create a new
   <div
     className="card newprojectcard"
   >
-    <div
-      className="card-header"
+    <h2
+      className="card-primarytitle title-l"
     >
-      <h1
-        className="card-title title-l"
-      >
-        New Project
-      </h1>
-    </div>
+      New Project
+    </h2>
     <div
       className="card-divider"
     />
-    <div
-      className="card-body"
+    <form
+      className="form"
+      onSubmit={[Function]}
     >
-      <form
-        className="form"
-        onSubmit={[Function]}
+      <div
+        className="errorgroup"
+      />
+      <div
+        className="field"
       >
+        <label
+          className="label body-l"
+          htmlFor="name"
+        >
+          Name
+        </label>
+        <p
+          className="description caption-m"
+        >
+          The name of the project can only contain letters and numbers separated by dots, dashes or underscores.
+        </p>
+        <input
+          className="textfield"
+          id="name"
+          name="name"
+          onChange={[Function]}
+          placeholder="Enter the name"
+          type="text"
+          value=""
+        />
         <div
           className="errorgroup"
         />
-        <div
-          className="field"
+      </div>
+      <div
+        className="actiongroup"
+      >
+        <button
+          className="button button--primary"
+          disabled={true}
         >
-          <label
-            className="label body-l"
-            htmlFor="name"
-          >
-            Name
-          </label>
-          <p
-            className="description caption-m"
-          >
-            The name of the project can only contain letters and numbers separated by dots, dashes or underscores.
-          </p>
-          <input
-            className="text"
-            id="name"
-            name="name"
-            onChange={[Function]}
-            placeholder="Enter the name"
-            type="text"
-            value=""
-          />
-          <div
-            className="errorgroup"
-          />
-        </div>
-        <div
-          className="actiongroup"
-        >
-          <button
-            className="button button--primary"
-            disabled={true}
-          >
-            Create Project
-          </button>
-        </div>
-      </form>
-    </div>
+          Create Project
+        </button>
+      </div>
+    </form>
   </div>
 </div>
 `;
@@ -150,18 +134,14 @@ exports[`NewProjectView renders an error card for an unsupported state 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      The new project page is in an unsupported state: INITIAL__STATE
-    </h1>
-    <p>
-      Contact your administrator to find a suitable solution (code: 1001)
-    </p>
-  </div>
+    The new project page is in an unsupported state: INITIAL__STATE
+  </h1>
+  <p>
+    Contact your administrator to find a suitable solution (code: 1001)
+  </p>
 </div>
 `;
 
@@ -172,79 +152,71 @@ exports[`NewProjectView renders errors message 1`] = `
   <div
     className="card newprojectcard"
   >
-    <div
-      className="card-header"
+    <h2
+      className="card-primarytitle title-l"
     >
-      <h1
-        className="card-title title-l"
-      >
-        New Project
-      </h1>
-    </div>
+      New Project
+    </h2>
     <div
       className="card-divider"
     />
-    <div
-      className="card-body"
+    <form
+      className="form"
+      onSubmit={[Function]}
     >
-      <form
-        className="form"
-        onSubmit={[Function]}
+      <div
+        className="errorgroup"
       >
+        <div
+          className="error"
+        >
+          Project already exists
+        </div>
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="label body-l"
+          htmlFor="name"
+        >
+          Name
+        </label>
+        <p
+          className="description caption-m"
+        >
+          The name of the project can only contain letters and numbers separated by dots, dashes or underscores.
+        </p>
+        <input
+          className="textfield fielderror"
+          id="name"
+          name="name"
+          onChange={[Function]}
+          placeholder="Enter the name"
+          type="text"
+          value=":\\\\/."
+        />
         <div
           className="errorgroup"
         >
           <div
             className="error"
           >
-            Project already exists
+            Invalid name
           </div>
         </div>
-        <div
-          className="field"
+      </div>
+      <div
+        className="actiongroup"
+      >
+        <button
+          className="button button--primary"
+          disabled={true}
         >
-          <label
-            className="label body-l"
-            htmlFor="name"
-          >
-            Name
-          </label>
-          <p
-            className="description caption-m"
-          >
-            The name of the project can only contain letters and numbers separated by dots, dashes or underscores.
-          </p>
-          <input
-            className="text fielderror"
-            id="name"
-            name="name"
-            onChange={[Function]}
-            placeholder="Enter the name"
-            type="text"
-            value=":\\\\/."
-          />
-          <div
-            className="errorgroup"
-          >
-            <div
-              className="error"
-            >
-              Invalid name
-            </div>
-          </div>
-        </div>
-        <div
-          className="actiongroup"
-        >
-          <button
-            className="button button--primary"
-            disabled={true}
-          >
-            Create Project
-          </button>
-        </div>
-      </form>
-    </div>
+          Create Project
+        </button>
+      </div>
+    </form>
   </div>
 </div>
 `;

--- a/src/components/projects/project/__tests__/__snapshots__/ProjectView.test.js.snap
+++ b/src/components/projects/project/__tests__/__snapshots__/ProjectView.test.js.snap
@@ -12,18 +12,14 @@ exports[`ProjectView renders an error card for an error 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      An error has occurred
-    </h1>
-    <p>
-      Please contact the administrator to try to find a solution (code: 500)
-    </p>
-  </div>
+    An error has occurred
+  </h1>
+  <p>
+    Please contact the administrator to try to find a solution (code: 500)
+  </p>
 </div>
 `;
 
@@ -31,18 +27,14 @@ exports[`ProjectView renders an error card for an unsupported state 1`] = `
 <div
   className="card errorcard"
 >
-  <div
-    className="card-body"
+  <h1
+    className="title-l"
   >
-    <h1
-      className="title-l"
-    >
-      The project is in an unsupported state: INITIAL__STATE
-    </h1>
-    <p>
-      Contact your administrator to find a suitable solution (code: 1001)
-    </p>
-  </div>
+    The project is in an unsupported state: INITIAL__STATE
+  </h1>
+  <p>
+    Contact your administrator to find a suitable solution (code: 1001)
+  </p>
 </div>
 `;
 
@@ -53,15 +45,11 @@ exports[`ProjectView renders the project 1`] = `
   <div
     className="card projectheadercard"
   >
-    <div
-      className="card-header"
+    <h1
+      className="card-herotitle title-xl"
     >
-      <h1
-        className="card-title title-xl"
-      >
-        Project
-      </h1>
-    </div>
+      Project
+    </h1>
   </div>
   <div
     className="projectview-main"
@@ -72,81 +60,68 @@ exports[`ProjectView renders the project 1`] = `
       <div
         className="card projectsemanticresourceslistcard"
       >
-        <div
-          className="card-header"
+        <h2
+          className="card-primarytitle title-l"
         >
-          <h1
-            className="card-title title-l"
-          >
-            Semantic Resources
-          </h1>
-        </div>
-        <div
-          className="card-body"
+          Semantic Resources
+        </h2>
+        <ul
+          className="list list--highlighted"
         >
-          <ul
-            className="list list--highlighted"
+          <li
+            className="tile tile--singleline"
           >
-            <li
-              className="tile tile--singleline"
+            <h4
+              className="tile-maintext body-s"
             >
-              <h4
-                className="tile-maintext body-s"
-              >
-                /model/model.ecore
-              </h4>
-            </li>
-          </ul>
-        </div>
+              /model/model.ecore
+            </h4>
+            <div
+              className="semanticresources-size caption-s"
+            />
+          </li>
+        </ul>
       </div>
       <div
         className="card projectrepresentationslistcard"
       >
-        <div
-          className="card-header"
+        <h2
+          className="card-primarytitle title-l"
         >
-          <h1
-            className="card-title title-l"
-          >
-            Representations
-          </h1>
-        </div>
-        <div
-          className="card-body"
+          Representations
+        </h2>
+        <ul
+          className="list list--highlighted"
         >
-          <ul
-            className="list list--highlighted"
+          <li
+            className="tile tile--twoline"
           >
-            <li
-              className="tile tile--twoline"
-            >
-              <div>
-                <h4
-                  className="tile-maintext body-s"
-                >
-                  Class Diagram
-                </h4>
-                <h5
-                  className="tile-additionaltext caption-xs"
-                />
-              </div>
-            </li>
-            <li
-              className="tile tile--twoline"
-            >
-              <div>
-                <h4
-                  className="tile-maintext body-s"
-                >
-                  Activity Diagram
-                </h4>
-                <h5
-                  className="tile-additionaltext caption-xs"
-                />
-              </div>
-            </li>
-          </ul>
-        </div>
+            <div>
+              <h4
+                className="tile-maintext body-s"
+              >
+                Class Diagram
+              </h4>
+              <h5
+                className="tile-additionaltext caption-xs"
+              />
+            </div>
+          </li>
+          <li
+            className="tile tile--twoline"
+          >
+            <div>
+              <h4
+                className="tile-maintext body-s"
+              >
+                Activity Diagram
+              </h4>
+              <h5
+                className="tile-additionaltext caption-xs"
+              />
+            </div>
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -155,38 +130,30 @@ exports[`ProjectView renders the project 1`] = `
       <div
         className="card workflowcard"
       >
-        <div
-          className="card-header"
+        <h2
+          className="card-primarytitle title-l"
         >
-          <h1
-            className="card-title title-l"
-          >
-            Workflow
-          </h1>
-        </div>
+          Workflow
+        </h2>
         <div
-          className="card-body"
+          className="tabbar"
         >
           <div
-            className="tabbar"
+            className="tabbar-nav tabbar-nav--disabled"
+            data-side="previous"
+            onClick={[Function]}
           >
-            <div
-              className="tabbar-nav tabbar-nav--disabled"
-              data-side="previous"
-              onClick={[Function]}
-            >
-              &lt;
-            </div>
-            <div
-              className="tabbar-tabs"
-            />
-            <div
-              className="tabbar-nav tabbar-nav--disabled"
-              data-side="next"
-              onClick={[Function]}
-            >
-              &gt;
-            </div>
+            &lt;
+          </div>
+          <div
+            className="tabbar-tabs"
+          />
+          <div
+            className="tabbar-nav tabbar-nav--disabled"
+            data-side="next"
+            onClick={[Function]}
+          >
+            &gt;
           </div>
         </div>
       </div>

--- a/src/components/workflow/WorkflowCard.css
+++ b/src/components/workflow/WorkflowCard.css
@@ -7,9 +7,13 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
+.workflowcard .card-divider {
+  margin: 0 var(--layoutDimension-m);
+}
 .section-title {
   padding: var(--layoutDimension-m) var(--layoutDimension-m) 0 var(--layoutDimension-m);
 }
+
 .section .listitem {
   display: grid;
   grid-template-columns: auto min-content;

--- a/src/components/workflow/WorkflowCard.js
+++ b/src/components/workflow/WorkflowCard.js
@@ -7,12 +7,12 @@
  * https://www.eclipse.org/legal/epl-2.0.
  *******************************************************************************/
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { classNames } from '../../common/classnames';
 
-import { Body, Card, Header, Title } from '../cards/Card';
+import { Card, Divider, PrimaryTitle, SecondaryTitle } from '../cards/Card';
 import { IconRun } from '../icons/IconRun';
 import {
   List,
@@ -68,16 +68,14 @@ export const WorkflowCard = ({
   const workflowCardClassNames = classNames(WORKFLOWCARD__CLASS_NAMES, className);
   return (
     <Card {...props} className={workflowCardClassNames}>
-      <Header>
-        <Title>Workflow</Title>
-      </Header>
-      <Body>
-        <TabBar
-          selectedTabIndex={selectedTabIndex}
-          tabs={pages.map(page => page.name)}
-          onTabClick={onTabClick}
-        />
-        {sections.map(section => (
+      <PrimaryTitle label="Workflow" />
+      <TabBar
+        selectedTabIndex={selectedTabIndex}
+        tabs={pages.map(page => page.name)}
+        onTabClick={onTabClick}
+      />
+      {sections.map((section, index) => (
+        <Fragment key={section.identifier}>
           <Section
             key={section.identifier}
             projectName={projectName}
@@ -85,8 +83,9 @@ export const WorkflowCard = ({
             section={section}
             onActivityClick={onActivityClick}
           />
-        ))}
-      </Body>
+          {index + 1 < sections.length ? <Divider /> : null}
+        </Fragment>
+      ))}
     </Card>
   );
 };
@@ -94,7 +93,6 @@ WorkflowCard.propTypes = propTypes;
 WorkflowCard.defaultProps = defaultProps;
 
 const SECTION__CLASS_NAMES = 'section';
-const SECTION_TITLE__CLASS_NAMES = 'section-title title-s';
 
 const Section = ({
   className,
@@ -107,7 +105,7 @@ const Section = ({
   const sectionClassNames = classNames(SECTION__CLASS_NAMES, className);
   return (
     <div className={sectionClassNames} {...props}>
-      <h2 className={SECTION_TITLE__CLASS_NAMES}>{section.name}</h2>
+      <SecondaryTitle label={section.name} />
       <List kind={LIST_WITH_HIGHLIGHT__KIND}>
         {section.activities.map(activity => (
           <SingleLineTile key={activity.identifier}>

--- a/src/components/workflow/__tests__/__snapshots__/WorkflowCard.test.js.snap
+++ b/src/components/workflow/__tests__/__snapshots__/WorkflowCard.test.js.snap
@@ -4,159 +4,154 @@ exports[`WorkflowCard renders the workflow card 1`] = `
 <div
   className="card workflowcard"
 >
-  <div
-    className="card-header"
+  <h2
+    className="card-primarytitle title-l"
   >
-    <h1
-      className="card-title title-l"
+    Workflow
+  </h2>
+  <div
+    className="tabbar"
+  >
+    <div
+      className="tabbar-nav tabbar-nav--disabled"
+      data-side="previous"
+      onClick={[Function]}
     >
-      Workflow
-    </h1>
+      &lt;
+    </div>
+    <div
+      className="tabbar-tabs"
+    >
+      <div
+        className="tabbar-tab title-m tabbar-tab--selected"
+        data-index={0}
+        onClick={[Function]}
+      >
+        Test Page
+      </div>
+      <div
+        className="tabbar-tab title-m"
+        data-index={1}
+        onClick={[Function]}
+      >
+        Test Page 1
+      </div>
+      <div
+        className="tabbar-tab title-m"
+        data-index={2}
+        onClick={[Function]}
+      >
+        Test Page 2
+      </div>
+    </div>
+    <div
+      className="tabbar-nav"
+      data-side="next"
+      onClick={[Function]}
+    >
+      &gt;
+    </div>
   </div>
   <div
-    className="card-body"
+    className="section"
   >
-    <div
-      className="tabbar"
+    <h3
+      className="card-secondarytitle title-m"
     >
-      <div
-        className="tabbar-nav tabbar-nav--disabled"
-        data-side="previous"
-        onClick={[Function]}
-      >
-        &lt;
-      </div>
-      <div
-        className="tabbar-tabs"
-      >
-        <div
-          className="tabbar-tab title-m tabbar-tab--selected"
-          data-index={0}
-          onClick={[Function]}
-        >
-          Test Page
-        </div>
-        <div
-          className="tabbar-tab title-m"
-          data-index={1}
-          onClick={[Function]}
-        >
-          Test Page 1
-        </div>
-        <div
-          className="tabbar-tab title-m"
-          data-index={2}
-          onClick={[Function]}
-        >
-          Test Page 2
-        </div>
-      </div>
-      <div
-        className="tabbar-nav"
-        data-side="next"
-        onClick={[Function]}
-      >
-        &gt;
-      </div>
-    </div>
-    <div
-      className="section"
+      Test Section
+    </h3>
+    <ul
+      className="list list--highlighted"
     >
-      <h2
-        className="section-title title-s"
+      <li
+        className="tile tile--singleline"
       >
-        Test Section
-      </h2>
-      <ul
-        className="list list--highlighted"
+        <h4
+          className="tile-maintext body-s"
+        >
+          Test Activity
+        </h4>
+        <div
+          className="tile-additionalicon"
+        >
+          <svg
+            className="iconrun"
+            height="16"
+            onClick={[Function]}
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              points="0,0 16,8 0,16"
+            />
+          </svg>
+        </div>
+      </li>
+      <li
+        className="tile tile--singleline"
       >
-        <li
-          className="tile tile--singleline"
+        <h4
+          className="tile-maintext body-s"
         >
-          <h4
-            className="tile-maintext body-s"
-          >
-            Test Activity
-          </h4>
-          <div
-            className="tile-additionalicon"
-          >
-            <svg
-              className="iconrun"
-              height="16"
-              onClick={[Function]}
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polygon
-                points="0,0 16,8 0,16"
-              />
-            </svg>
-          </div>
-        </li>
-        <li
-          className="tile tile--singleline"
+          Test Activity 1
+        </h4>
+        <div
+          className="tile-additionalicon"
         >
-          <h4
-            className="tile-maintext body-s"
+          <svg
+            className="iconrun"
+            height="16"
+            onClick={[Function]}
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            Test Activity 1
-          </h4>
-          <div
-            className="tile-additionalicon"
-          >
-            <svg
-              className="iconrun"
-              height="16"
-              onClick={[Function]}
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polygon
-                points="0,0 16,8 0,16"
-              />
-            </svg>
-          </div>
-        </li>
-      </ul>
-    </div>
-    <div
-      className="section"
+            <polygon
+              points="0,0 16,8 0,16"
+            />
+          </svg>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="card-divider"
+  />
+  <div
+    className="section"
+  >
+    <h3
+      className="card-secondarytitle title-m"
     >
-      <h2
-        className="section-title title-s"
+      Test Section 1
+    </h3>
+    <ul
+      className="list list--highlighted"
+    >
+      <li
+        className="tile tile--singleline"
       >
-        Test Section 1
-      </h2>
-      <ul
-        className="list list--highlighted"
-      >
-        <li
-          className="tile tile--singleline"
+        <h4
+          className="tile-maintext body-s"
         >
-          <h4
-            className="tile-maintext body-s"
+          Test Activity
+        </h4>
+        <div
+          className="tile-additionalicon"
+        >
+          <svg
+            className="iconrun"
+            height="16"
+            onClick={[Function]}
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            Test Activity
-          </h4>
-          <div
-            className="tile-additionalicon"
-          >
-            <svg
-              className="iconrun"
-              height="16"
-              onClick={[Function]}
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polygon
-                points="0,0 16,8 0,16"
-              />
-            </svg>
-          </div>
-        </li>
-      </ul>
-    </div>
+            <polygon
+              points="0,0 16,8 0,16"
+            />
+          </svg>
+        </div>
+      </li>
+    </ul>
   </div>
 </div>
 `;


### PR DESCRIPTION
This commit will improve the layout of the components used to create
cards. Some components have been removed or restructured like Header,
Body, Footer and Title in order to be easier to use. It should also less
complex to make them evolve in the future.

Bug: https://github.com/eclipse/sirius-components/issues/37
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non*breaking change which fixes an issue)
* [ ] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] I have read the **CONTRIBUTING** document.
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] Continuous integration improvement