### PR TITLE
Issue on using prettier cli on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test": "react-scripts test --env=jsdom",
     "coverage": "react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject",
-    "lint": "eslint 'src/**/*.{js,jsx}'",
-    "format": "prettier --write 'src/**/*.{js,css}'",
-    "format-lint": "prettier --list-different 'src/**/*.{js,css}'"
+    "lint": "eslint \"src/**/*.{js,jsx}\"",
+    "format": "prettier --write \"src/**/*.{js,css}\"",
+    "format-lint": "prettier --list-different \"src/**/*.{js,css}\""
   },
   "proxy": {
     "/api": {


### PR DESCRIPTION
Use double quotes instead of single quotes in order to make
prettier work on windows.

Bug: https://github.com/eclipse/sirius-components/issues/47
Signed-off-by: Guillaume Coutable <guillaume.coutable@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non*breaking change which fixes an issue)
* [ ] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] Continuous integration improvement