### PR TITLE
All project cards should have the same height

### DIFF
--- a/src/components/dashboard/DashboardView.css
+++ b/src/components/dashboard/DashboardView.css
@@ -38,6 +38,7 @@
 
 .dashboardview .projects-body {
   display: grid;
+  grid-auto-rows: 1fr;
   grid-template-rows: 1fr 1fr;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   grid-row-gap: var(--layoutDimension-l);


### PR DESCRIPTION
Make all the projects card in the dashboard have the same height.

Bug: https://github.com/eclipse/sirius-components/issues/55
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non*breaking change which fixes an issue)
* [ ] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] Continuous integration improvement