### PR TITLE
Add support for deployment at a specific path

### DIFF
--- a/docs/development.adoc
+++ b/docs/development.adoc
@@ -1,6 +1,6 @@
 = Development Guide
 Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
-v1.0.0, 2018-03-23
+v1.0.1, 2018-08-09
 
 == Environment
 
@@ -37,6 +37,8 @@ To execute the tests only once with code coverage, use `yarn coverage`.
 Coverage reports will be generated in the coverage folder.
 
 Finally, to build the production version of the code which can be deployed on a server, you should use `yarn build`.
+If you want to build the code to deploy it at a specific path, for example `/workflow` instead of `/`, you can use the `PUBLIC_URL` environment variable in your build.
+Have a look at the create-react-app documentation for additional information regarding environment variables.
 
 == Server
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import './app.css';
  * The entry point of the application.
  */
 ReactDOM.render(
-  <BrowserRouter>
+  <BrowserRouter basename={process.env.PUBLIC_URL || ''}>
     <App />
   </BrowserRouter>,
   document.getElementById('root')


### PR DESCRIPTION
While building the project, we can now specify the path where the code
will be deployed in order to make the loading of resources and the
router work.

If you want to deploy the code at the path /workflow, you would have to
set the environment variable PUBLIC_URL to /workflow before the build.

Bug: https://github.com/eclipse/sirius-components/issues/93
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non*breaking change which fixes an issue)
* [x] New feature (non*breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] I have read the **CONTRIBUTING** document.
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [ ] Continuous integration improvement